### PR TITLE
refactor(vad-trt): encapsulate image, can_bus, and lidar2img transformations in nested functions

### DIFF
--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -619,11 +619,58 @@ load_can_bus_shift_from_rosbag_single_frame(
     int frame_id,
     const std::vector<float> &prev_can_bus = {}) {
 
+  // can_busデータの構築を関数内関数として切り出し
+  auto build_can_bus_data = [&](const std::vector<float> &translation,
+                                const std::vector<float> &rotation,
+                                const std::vector<float> &acceleration,
+                                const std::vector<float> &angular_velocity,
+                                const std::vector<float> &velocity,
+                                const std::vector<float> &prev_can_bus,
+                                int frame_id,
+                                float default_patch_angle) -> std::vector<float> {
+    std::vector<float> can_bus(18, 0.0f);
+
+    // translation (0:3)
+    std::copy(translation.begin(), translation.end(), can_bus.begin());
+
+    // rotation (3:7)
+    std::copy(rotation.begin(), rotation.end(), can_bus.begin() + 3);
+
+    // acceleration (7:10)
+    std::copy(acceleration.begin(), acceleration.end(), can_bus.begin() + 7);
+
+    // angular velocity (10:13)
+    std::copy(angular_velocity.begin(), angular_velocity.end(),
+              can_bus.begin() + 10);
+
+    // velocity (13:16)
+    std::copy(velocity.begin(), velocity.begin() + 2, can_bus.begin() + 13);
+    can_bus[15] = 0.0f; // z方向の速度は0とする
+
+    // patch_angle[rad]の計算 (16)
+    double yaw = std::atan2(
+        2.0 * (can_bus[6] * can_bus[5] + can_bus[3] * can_bus[4]),
+        1.0 - 2.0 * (can_bus[4] * can_bus[4] + can_bus[5] * can_bus[5]));
+    if (yaw < 0)
+      yaw += 2 * M_PI;
+    can_bus[16] = static_cast<float>(yaw);
+
+    // patch_angle[deg]の計算 (17)
+    if (frame_id > 0 && !prev_can_bus.empty()) {
+      float prev_angle = prev_can_bus[16];
+      can_bus[17] = (yaw - prev_angle) * 180.0f / M_PI;
+    } else {
+      can_bus[17] = default_patch_angle; // 最初のフレームのデフォルト値
+    }
+
+    return can_bus;
+  };
+
   // default patch_angle
   float default_patch_angle = -1.0353195667266846f;
 
-  std::vector<float> can_bus(18, 0.0f);
-  std::vector<float> shift(2, 0.0f);
+  std::vector<float> can_bus;
+  std::vector<float> shift;
 
   // Apply Autoware to nuScenes coordinate transformation to position
   auto [ns_x, ns_y] =
@@ -677,44 +724,20 @@ load_can_bus_shift_from_rosbag_single_frame(
       static_cast<float>(imu_raw->linear_acceleration.z)};
 
   // can_busデータの構築（18次元ベクトル）
-
-  // translation (0:3)
-  std::copy(translation.begin(), translation.end(), can_bus.begin());
-
-  // rotation (3:7)
-  std::copy(rotation.begin(), rotation.end(), can_bus.begin() + 3);
-
-  // acceleration (7:10)
-  std::copy(acceleration.begin(), acceleration.end(), can_bus.begin() + 7);
-
-  // angular velocity (10:13)
-  std::copy(angular_velocity.begin(), angular_velocity.end(),
-            can_bus.begin() + 10);
-
-  // velocity (13:16)
-  std::copy(velocity.begin(), velocity.begin() + 2, can_bus.begin() + 13);
-  can_bus[15] = 0.0f; // z方向の速度は0とする
-
-  // patch_angle[rad]の計算 (16)
-  double yaw = std::atan2(
-      2.0 * (can_bus[6] * can_bus[5] + can_bus[3] * can_bus[4]),
-      1.0 - 2.0 * (can_bus[4] * can_bus[4] + can_bus[5] * can_bus[5]));
-  if (yaw < 0)
-    yaw += 2 * M_PI;
-  can_bus[16] = static_cast<float>(yaw);
-
-  // patch_angle[deg]の計算 (17)
-  if (frame_id > 0 && !prev_can_bus.empty()) {
-    float prev_angle = prev_can_bus[16];
-    can_bus[17] = (yaw - prev_angle) * 180.0f / M_PI;
-  } else {
-    can_bus[17] = default_patch_angle; // 最初のフレームのデフォルト値
-  }
+  can_bus = build_can_bus_data(
+      translation, rotation, acceleration, angular_velocity, velocity,
+      prev_can_bus, frame_id, default_patch_angle);
 
   // シフトデータの計算
   if (frame_id > 0 && !prev_can_bus.empty()) {
     float delta_x = translation[0] - prev_can_bus[0];
     float delta_y = translation[1] - prev_can_bus[1];
+
+    double yaw = std::atan2(
+        2.0 * (can_bus[6] * can_bus[5] + can_bus[3] * can_bus[4]),
+        1.0 - 2.0 * (can_bus[4] * can_bus[4] + can_bus[5] * can_bus[5]));
+    if (yaw < 0)
+      yaw += 2 * M_PI;
 
     shift = calculateShift(delta_x, delta_y, yaw);
   } else {

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -458,6 +458,26 @@ load_image_from_rosbag_single_frame(const std::vector<sensor_msgs::msg::Image::C
     return std::make_tuple(resized_data, target_width, target_height);
   };
 
+  // 画像正規化処理を関数内関数として切り出し
+  auto normalize_image = [](unsigned char *image_data, int32_t width, int32_t height, 
+                           const float mean[3], const float std[3]) -> std::vector<float> {
+    std::vector<float> normalized_image_data(width * height * 3);
+    
+    // BGRの順で処理
+    for (int c = 0; c < 3; ++c) {
+      for (int h = 0; h < height; ++h) {
+        for (int w = 0; w < width; ++w) {
+          int32_t src_idx = (h * width + w) * 3 + (2 - c); // BGR -> RGB
+          int32_t dst_idx = c * height * width + h * width + w; // CHW形式
+          float pixel_value = static_cast<float>(image_data[src_idx]);
+          normalized_image_data[dst_idx] = (pixel_value - mean[c]) / std[c];
+        }
+      }
+    }
+    
+    return normalized_image_data;
+  };
+
   std::vector<std::vector<float>> frame_images;
   frame_images.resize(6); // VADカメラ順序で初期化
 
@@ -502,18 +522,8 @@ load_image_from_rosbag_single_frame(const std::vector<sensor_msgs::msg::Image::C
       }
     }
 
-    // BGRの順で処理
-    std::vector<float> normalized_image_data(width * height * 3);
-    for (int c = 0; c < 3; ++c) {
-      for (int h = 0; h < height; ++h) {
-        for (int w = 0; w < width; ++w) {
-          int32_t src_idx = (h * width + w) * 3 + (2 - c); // BGR -> RGB
-          int32_t dst_idx = c * height * width + h * width + w; // CHW形式
-          float pixel_value = static_cast<float>(image_data[src_idx]);
-          normalized_image_data[dst_idx] = (pixel_value - mean[c]) / std[c];
-        }
-      }
-    }
+    // 画像を正規化
+    std::vector<float> normalized_image_data = normalize_image(image_data, width, height, mean, std);
 
     // VADカメラ順序で格納
     int vad_idx = autoware_to_vad[autoware_idx];

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -800,6 +800,18 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
     return scale_matrix * lidar2img;
   };
 
+  // 4x4行列を1次元ベクトルに変換する処理を関数内関数として切り出し
+  auto matrix_to_flat = [](const Eigen::Matrix4f &matrix) -> std::vector<float> {
+    std::vector<float> flat(16);
+    int32_t k = 0;
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        flat[k++] = matrix(i, j);
+      }
+    }
+    return flat;
+  };
+
   std::vector<float> frame_lidar2img(16 * 6, 0.0f); // 6カメラ分のスペースを確保
 
   // AutowareカメラインデックスからVADカメラインデックスへのマッピング
@@ -873,13 +885,7 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
         lidar2img = apply_scaling(lidar2img, scale_width, scale_height);
 
         // 結果を格納
-        std::vector<float> lidar2img_flat(16);
-        int32_t k = 0;
-        for (int i = 0; i < 4; ++i) {
-          for (int j = 0; j < 4; ++j) {
-            lidar2img_flat[k++] = lidar2img(i, j);
-          }
-        }
+        std::vector<float> lidar2img_flat = matrix_to_flat(lidar2img);
 
         // lidar2imgの計算後、VADカメラIDの位置に格納
         int vad_camera_id = autoware_to_vad[autoware_camera_id];

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -812,6 +812,17 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
     return flat;
   };
 
+  // camera_infoからk_matrixを作成する処理を関数内関数として切り出し
+  auto create_k_matrix = [](const sensor_msgs::msg::CameraInfo::ConstSharedPtr &camera_info) -> Eigen::Matrix3f {
+    Eigen::Matrix3f k_matrix;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        k_matrix(i, j) = camera_info->k[i * 3 + j];
+      }
+    }
+    return k_matrix;
+  };
+
   std::vector<float> frame_lidar2img(16 * 6, 0.0f); // 6カメラ分のスペースを確保
 
   // AutowareカメラインデックスからVADカメラインデックスへのマッピング
@@ -839,13 +850,7 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
           camera_infos[autoware_camera_id]) {
 
         // カメラ行列Kを3x3行列として抽出
-        Eigen::Matrix3f k_matrix;
-        const auto &camera_info = camera_infos[autoware_camera_id];
-        for (int i = 0; i < 3; ++i) {
-          for (int j = 0; j < 3; ++j) {
-            k_matrix(i, j) = camera_info->k[i * 3 + j];
-          }
-        }
+        Eigen::Matrix3f k_matrix = create_k_matrix(camera_infos[autoware_camera_id]);
 
         // 変換行列の構築
         Eigen::Vector3f aw_translation(transform.transform.translation.x,

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -439,6 +439,25 @@ private:
 std::vector<std::vector<float>>
 load_image_from_rosbag_single_frame(const std::vector<sensor_msgs::msg::Image::ConstSharedPtr> &images, int frame_id) {
 
+  // 画像リサイズ処理を関数内関数として切り出し
+  auto resize_image = [](unsigned char *image_data, int32_t width, int32_t height, int32_t channels, 
+                         int32_t target_width, int32_t target_height) -> std::optional<std::tuple<unsigned char*, int32_t, int32_t>> {
+    unsigned char *resized_data = (unsigned char *)malloc(target_width * target_height * channels);
+    
+    int resize_result = stbir_resize_uint8(image_data, width, height, 0, resized_data,
+                                          target_width, target_height, 0, channels);
+    
+    if (!resize_result) {
+      free(resized_data);
+      return std::nullopt;
+    }
+    
+    // 元のデータを解放
+    stbi_image_free(image_data);
+    
+    return std::make_tuple(resized_data, target_width, target_height);
+  };
+
   std::vector<std::vector<float>> frame_images;
   frame_images.resize(6); // VADカメラ順序で初期化
 
@@ -471,22 +490,16 @@ load_image_from_rosbag_single_frame(const std::vector<sensor_msgs::msg::Image::C
         &width, &height, &channels, STBI_rgb); // RGBとして読み込む
 
     // サイズが目標と違う場合はリサイズする
-    unsigned char *resized_data = nullptr;
     if (width != target_width || height != target_height) {
-      // stb_image_resizeを使用してリサイズ
-      resized_data =
-          (unsigned char *)malloc(target_width * target_height * channels);
-
-      // stb_image_resizeを使ってリサイズ
-      int resize_result =
-          stbir_resize_uint8(image_data, width, height, 0, resized_data,
-                              target_width, target_height, 0, channels);
-
-      // 元のデータを解放し、リサイズしたデータを使用
-      stbi_image_free(image_data);
-      image_data = resized_data;
-      width = target_width;
-      height = target_height;
+      auto resize_result = resize_image(image_data, width, height, channels, target_width, target_height);
+      
+      if (resize_result.has_value()) {
+        // リサイズされたデータとサイズを取得
+        auto [new_image_data, new_width, new_height] = resize_result.value();
+        image_data = new_image_data;
+        width = new_width;
+        height = new_height;
+      }
     }
 
     // BGRの順で処理

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -792,6 +792,14 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
     int frame_id,
     float scale_width, float scale_height) {
   
+  // スケーリング処理を関数内関数として切り出し
+  auto apply_scaling = [](const Eigen::Matrix4f &lidar2img, float scale_width, float scale_height) -> Eigen::Matrix4f {
+    Eigen::Matrix4f scale_matrix = Eigen::Matrix4f::Identity();
+    scale_matrix(0, 0) = scale_width;
+    scale_matrix(1, 1) = scale_height;
+    return scale_matrix * lidar2img;
+  };
+
   std::vector<float> frame_lidar2img(16 * 6, 0.0f); // 6カメラ分のスペースを確保
 
   // AutowareカメラインデックスからVADカメラインデックスへのマッピング
@@ -862,11 +870,7 @@ std::vector<float> load_lidar2img_from_rosbag_single_frame(
         Eigen::Matrix4f lidar2img = viewpad * lidar2cam_rt_T;
 
         // スケーリングを適用
-        Eigen::Matrix4f scale_matrix = Eigen::Matrix4f::Identity();
-        scale_matrix(0, 0) = scale_width;
-        scale_matrix(1, 1) = scale_height;
-
-        lidar2img = scale_matrix * lidar2img;
+        lidar2img = apply_scaling(lidar2img, scale_width, scale_height);
 
         // 結果を格納
         std::vector<float> lidar2img_flat(16);


### PR DESCRIPTION
# Description

This PR refactors the VAD-TRT application by encapsulating complex transformation logic into nested functions, improving code readability and maintainability.

## Changes

### Image Processing
- **Resize**: Extracted image resizing logic into `resize_image` nested function with proper error handling using `std::optional`
- **Normalize**: Encapsulated image normalization (BGR to RGB conversion and CHW format transformation) into `normalize_image` nested function

### CAN Bus Processing
- Extracted CAN bus data construction logic into `build_can_bus_data` nested function, handling translation, rotation, acceleration, angular velocity, velocity, and patch angle calculations

### LiDAR2Img Processing
- **K-Matrix Creation**: Encapsulated camera intrinsic matrix extraction from camera_info into `create_k_matrix` nested function
- **Scaling**: Extracted scaling matrix application into `apply_scaling` nested function with return value
- **Flattening**: Encapsulated 4x4 matrix to 1D vector conversion into `matrix_to_flat` nested function

## Benefits

- **Improved Readability**: Complex transformation logic is now clearly separated and easier to understand

# How this PR tested

<details>
<summary>log</summary>

```bash
~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build dev/ns-ros-node-refactor/simplify-load-func ≡ autoware@dpc2308007
❯ cmake .. -DBUILD_TESTS=ON -DTARGET=x86_64 -DTRT_ROOT=/home/autoware/ghq/github.com/NVIDIA/TensorRT
-- The CXX compiler identification is GNU 11.4.0
-- The CUDA compiler identification is NVIDIA 12.3.107
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib/ccache/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found ament_cmake: 1.3.7 (/home/autoware/ghq/github.com/tier4/pilot-auto.xx1-beta-v0.47/pilot-auto.xx1/install/ament_cmake/share/ament_cmake/cmake)
-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
-- Found rclcpp: 16.0.1 (/home/autoware/ghq/github.com/tier4/pilot-auto.xx1-beta-v0.47/pilot-auto.xx1/install/rclcpp/share/rclcpp/cmake)
-- Found rosidl_generator_c: 3.1.6 (/opt/ros/humble/share/rosidl_generator_c/cmake)
-- Found rosidl_adapter: 3.1.6 (/opt/ros/humble/share/rosidl_adapter/cmake)
-- Found rosidl_generator_cpp: 3.1.6 (/opt/ros/humble/share/rosidl_generator_cpp/cmake)
-- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
-- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
-- Found rmw_implementation_cmake: 6.1.2 (/opt/ros/humble/share/rmw_implementation_cmake/cmake)
-- Found rmw_cyclonedds_cpp: 1.3.4 (/opt/ros/humble/share/rmw_cyclonedds_cpp/cmake)
-- Using RMW implementation 'rmw_cyclonedds_cpp' as default
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found tf2_ros: 0.25.12 (/opt/ros/humble/share/tf2_ros/cmake)
-- Found tf2_eigen: 0.25.12 (/opt/ros/humble/share/tf2_eigen/cmake)
-- Found eigen3_cmake_module: 0.1.1 (/opt/ros/humble/share/eigen3_cmake_module/cmake)
-- Found Eigen3: TRUE (found version "3.4.0") 
-- Found sensor_msgs: 4.8.0 (/opt/ros/humble/share/sensor_msgs/cmake)
-- Found autoware_perception_msgs: 1.1.0 (/home/autoware/ghq/github.com/tier4/pilot-auto.xx1-beta-v0.47/pilot-auto.xx1/install/autoware_perception_msgs/share/autoware_perception_msgs/cmake)
-- Found autoware_planning_msgs: 1.1.0 (/home/autoware/ghq/github.com/tier4/pilot-auto.xx1-beta-v0.47/pilot-auto.xx1/install/autoware_planning_msgs/share/autoware_planning_msgs/cmake)
-- Found rosbag2_cpp: 0.15.14 (/opt/ros/humble/share/rosbag2_cpp/cmake)
-- Found CUDA: /usr/local/cuda (found version "12.3") 
-- Using the multi-header code from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build/_deps/json-src/include/
-- Configuring done
CMake Warning (dev) in CMakeLists.txt:
  Policy CMP0104 is not set: CMAKE_CUDA_ARCHITECTURES now detected for NVCC,
  empty CUDA_ARCHITECTURES not allowed.  Run "cmake --help-policy CMP0104"
  for policy details.  Use the cmake_policy command to set the policy and
  suppress this warning.

  CUDA_ARCHITECTURES is empty for target "vad_cu".
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  Policy CMP0104 is not set: CMAKE_CUDA_ARCHITECTURES now detected for NVCC,
  empty CUDA_ARCHITECTURES not allowed.  Run "cmake --help-policy CMP0104"
  for policy details.  Use the cmake_policy command to set the policy and
  suppress this warning.

  CUDA_ARCHITECTURES is empty for target "vad_cu".
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  Policy CMP0104 is not set: CMAKE_CUDA_ARCHITECTURES now detected for NVCC,
  empty CUDA_ARCHITECTURES not allowed.  Run "cmake --help-policy CMP0104"
  for policy details.  Use the cmake_policy command to set the policy and
  suppress this warning.

  CUDA_ARCHITECTURES is empty for target "vad_app".
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTS


-- Build files have been written to: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build

~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build dev/ns-ros-node-refactor/simplify-load-func ≡ autoware@dpc2308007 9s
❯ make
[  9%] Building CUDA object CMakeFiles/vad_cu.dir/lib/visualize.cu.o
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h: In member function ‘virtual bool nvinfer1::IGpuAllocator::deallocate(void*)’:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:479:11: warning: ‘virtual void nvinfer1::IGpuAllocator::free(void*)’ is deprecated [-Wdeprecated-declarations]
  479 |         this->free(memory);
      |         ~~^~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:410:29: note: declared here
  410 |     TRT_DEPRECATED virtual void free(void* const memory) noexcept = 0;
      |                             ^~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h: At global scope:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:866:102: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  866 |     virtual IPluginV2* createPlugin(AsciiChar const* name, PluginFieldCollection const* fc) noexcept = 0;
      |                                                                                                      ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:877:119: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  877 |     virtual IPluginV2* deserializePlugin(AsciiChar const* name, void const* serialData, size_t serialLength) noexcept
      |                                                                                                                       ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:648:51: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  648 |     virtual IPluginV2& getPlugin() noexcept = 0;
      |                                                   ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:1014:111: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 1014 |     virtual IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept = 0;
      |                                                                                                               ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:3647:32: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 3647 |     IPluginV2& getPlugin() noexcept
      |                                ^~~~    
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:7617:90: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 7617 |     IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept
      |                                                                                          ^~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
[ 18%] Building CUDA object CMakeFiles/vad_cu.dir/lib/cuOSD/cuosd_kernel.cu.o
[ 27%] Linking CUDA static library libvad_cu.a
[ 27%] Built target vad_cu
[ 36%] Building CXX object CMakeFiles/vad_app.dir/main.cpp.o
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:49:
/opt/ros/humble/include/tf2_eigen/tf2_eigen/tf2_eigen.h:32:2: warning: #warning This header is obsolete, please include tf2_eigen/tf2_eigen.hpp instead [-Wcpp]
   32 | #warning This header is obsolete, please include tf2_eigen/tf2_eigen.hpp instead
      |  ^~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:26,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h: In member function ‘virtual bool nvinfer1::IGpuAllocator::deallocate(void*)’:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:479:19: warning: ‘virtual void nvinfer1::IGpuAllocator::free(void*)’ is deprecated [-Wdeprecated-declarations]
  479 |         this->free(memory);
      |         ~~~~~~~~~~^~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:410:33: note: declared here
  410 |     TRT_DEPRECATED virtual void free(void* const memory) noexcept = 0;
      |                                 ^~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h: At global scope:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:866:104: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  866 |     virtual IPluginV2* createPlugin(AsciiChar const* name, PluginFieldCollection const* fc) noexcept = 0;
      |                                                                                                        ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:878:11: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  878 |         = 0;
      |           ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:22,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:648:47: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  648 |     virtual IPluginV2& getPlugin() noexcept = 0;
      |                                               ^
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:22,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:1014:113: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 1014 |     virtual IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept = 0;
      |                                                                                                                 ^
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:3647:28: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 3647 |     IPluginV2& getPlugin() noexcept
      |                            ^~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:7617:94: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 7617 |     IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept
      |                                                                                              ^~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/vad_model.hpp:27,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/ros_vad_logger.hpp:18,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:67:
/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/net.h: In destructor ‘nv::Net::~Net()’:
/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/net.h:94:27: warning: ‘void nvinfer1::IExecutionContext::destroy()’ is deprecated [-Wdeprecated-declarations]
   94 |           context->destroy();
      |           ~~~~~~~~~~~~~~~~^~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:2662:25: note: declared here
 2662 |     TRT_DEPRECATED void destroy() noexcept
      |                         ^~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/vad_model.hpp:27,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/ros_vad_logger.hpp:18,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:67:
/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/net.h:98:26: warning: ‘void nvinfer1::ICudaEngine::destroy()’ is deprecated [-Wdeprecated-declarations]
   98 |           engine->destroy();
      |           ~~~~~~~~~~~~~~~^~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/main.cpp:30:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:1770:25: note: declared here
 1770 |     TRT_DEPRECATED void destroy() noexcept
      |                         ^~~~~~~
[ 45%] Building CXX object CMakeFiles/vad_app.dir/lib/visualize.cpp.o
[ 54%] Building CXX object CMakeFiles/vad_app.dir/lib/tensor.cpp.o
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:26,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h: In member function ‘virtual bool nvinfer1::IGpuAllocator::deallocate(void*)’:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:479:19: warning: ‘virtual void nvinfer1::IGpuAllocator::free(void*)’ is deprecated [-Wdeprecated-declarations]
  479 |         this->free(memory);
      |         ~~~~~~~~~~^~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeBase.h:410:33: note: declared here
  410 |     TRT_DEPRECATED virtual void free(void* const memory) noexcept = 0;
      |                                 ^~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h: At global scope:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:866:104: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  866 |     virtual IPluginV2* createPlugin(AsciiChar const* name, PluginFieldCollection const* fc) noexcept = 0;
      |                                                                                                        ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:878:11: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  878 |         = 0;
      |           ^
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:22,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:648:47: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
  648 |     virtual IPluginV2& getPlugin() noexcept = 0;
      |                                               ^
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntime.h:22,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:17,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferImpl.h:1014:113: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 1014 |     virtual IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept = 0;
      |                                                                                                                 ^
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:3647:28: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 3647 |     IPluginV2& getPlugin() noexcept
      |                            ^~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
In file included from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:7617:94: warning: ‘IPluginV2’ is deprecated [-Wdeprecated-declarations]
 7617 |     IPluginV2Layer* addPluginV2(ITensor* const* inputs, int32_t nbInputs, IPluginV2& plugin) noexcept
      |                                                                                              ^~~~~~~~
In file included from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimeCommon.h:27,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferLegacyDims.h:16,
                 from /home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInfer.h:16,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.h:29,
                 from /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/lib/tensor.cpp:18:
/home/autoware/ghq/github.com/NVIDIA/TensorRT/include/NvInferRuntimePlugin.h:97:22: note: declared here
   97 | class TRT_DEPRECATED IPluginV2
      |                      ^~~~~~~~~
[ 63%] Building CXX object CMakeFiles/vad_app.dir/lib/cuOSD/cuosd.cpp.o
[ 72%] Building CXX object CMakeFiles/vad_app.dir/lib/cuOSD/textbackend/backend.cpp.o
[ 81%] Building CXX object CMakeFiles/vad_app.dir/lib/cuOSD/textbackend/stb.cpp.o
[ 90%] Linking CUDA device code CMakeFiles/vad_app.dir/cmake_device_link.o
[100%] Linking CXX executable vad_app
[100%] Built target vad_app

~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build dev/ns-ros-node-refactor/simplify-load-func ≡ autoware@dpc2308007 45s
❯ cd ../demo;../build/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1750657794.706156196] [vad_node]: VAD Node has been initialized
[INFO 1750657794.710490928] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1750657794.710532956] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1750657794.783492894] [vad_node]: -> engine: head_no_prev
[INFO 1750657794.783538217] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1750657795.002144219] [vad_node]: warm_up=20
[INFO] n_frames=30
[INFO] default_command=0
[INFO 1750657795.301670123] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/output_bag_0.db3' for READ_ONLY.
[INFO 1750657795.691072688] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1750657795.691119012] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=0 finished
publish trajectory[INFO] 2, cmd=0 finished
publish trajectory[INFO] 3, cmd=0 finished
publish trajectory[INFO] 4, cmd=0 finished
publish trajectory[INFO] 5, cmd=0 finished
publish trajectory[INFO] 6, cmd=0 finished
publish trajectory[INFO] 7, cmd=0 finished
publish trajectory[INFO] 8, cmd=0 finished
publish trajectory[INFO] 9, cmd=0 finished
publish trajectory[INFO] 10, cmd=0 finished
publish trajectory[INFO] 11, cmd=0 finished
publish trajectory[INFO] 12, cmd=0 finished
publish trajectory[INFO] 13, cmd=0 finished
publish trajectory[INFO] 14, cmd=0 finished
publish trajectory[INFO] 15, cmd=0 finished
publish trajectory[INFO] 16, cmd=0 finished
publish trajectory[INFO] 17, cmd=0 finished
publish trajectory[INFO] 18, cmd=0 finished
publish trajectory[INFO] 19, cmd=0 finished
publish trajectory[INFO] 20, cmd=0 finished
publish trajectory[INFO] 21, cmd=0 finished
publish trajectory[INFO] 22, cmd=0 finished
publish trajectory[INFO] 23, cmd=0 finished
publish trajectory[INFO] 24, cmd=0 finished
publish trajectory[INFO] 25, cmd=0 finished
publish trajectory[INFO] 26, cmd=0 finished
publish trajectory[INFO] 27, cmd=0 finished
publish trajectory[INFO] 28, cmd=0 finished
publish trajectory[INFO] 29, cmd=0 finished
```

</details>
