### PR TITLE
refactor(vad-trt): use cam2base in VadInterface

### DIFF
--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -1,15 +1,31 @@
 /**:
   ros__parameters:
     interface_params:
-      input_image_width: 1920
-      input_image_height: 1080
+      # # awsim
+      # input_image_width: 1920
+      # input_image_height: 1080
+      # # autoware xx1
+      # input_image_width: 1466
+      # input_image_height: 1122
+      # nuScenes
+      input_image_width: 1653
+      input_image_height: 940
+      # # autoware xx1
       target_image_width: 640
       target_image_height: 384
       point_cloud_range: [-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]
       bev_h: 100
       bev_w: 100
-      default_patch_angle: -1.0353195667266846
+      default_patch_angle: 0.0
       default_shift: [0.0, 0.0]
+      # default_can_bus[0:3] x, y, z in_map_coordinate
+      # default_can_bus[3:7] quaternion(x, y, z, w)
+      # default_can_bus[7:10] ax, ay, az
+      # default_can_bus[10:13] angular velocity(vx, vy, vz)
+      # default_can_bus[13:16] linear velocity(vx, vy, vz)
+      # default_can_bus[16] yaw[rad]
+      # default_can_bus[17] patch_angle(difference between yaw and prev_yaw)[deg]
+      default_can_bus: [-42274.0312, 89140.4531, 6.92498255, -0.00156072155, -0.0132345976, -0.475291312, 0.879727542, 0.158691406, -2.24609375, -9.72595215, 0.0, 0.0, 0.00481297961, 0.0, 2.15303349, 0.0, 5.19237747, 303.230896]
       image_normalization_param_mean: [103.530, 116.280, 123.675]
       image_normalization_param_std: [1.0, 1.0, 1.0]
       autoware_to_vad_camera_mapping: [0, 0, # FRONT

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -10,7 +10,6 @@
       # nuScenes
       input_image_width: 1653
       input_image_height: 940
-      # # autoware xx1
       target_image_width: 640
       target_image_height: 384
       point_cloud_range: [-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/docs/architecture_decision_records.md
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/docs/architecture_decision_records.md
@@ -1,0 +1,35 @@
+# `perv_can_bus` handling
+
+## Context and Problem Statement
+
+- `prev_can_bus`を誰が保持すべきか
+　- `prev_can_bus`は，`VadInputData`(正確にはその中のcan_busとshift)を計算する際に必要である
+  - これを，`VadNode`, `VadInterface`, `VadModel`のどこで持つべきか？
+- 参考: `prev_bev`は`VadModel`が保持している
+
+## Considered Options
+
+### 1. `VadModel`で持つ
+
+- こうすると，`VadInterface`の責任範囲である，「`VadInputTopicData`を`VadInputData`に変換する」が`VadModel`にも散らばってしまう．
+- よってこれは微妙
+
+### 2. `VadInterface`で持つ
+
+- すると，`VadInterface`が状態を持つことになる．
+- 「`VadInputTopicData`を`VadInputData`に変換する」という処理は複雑であり，ROSとVADのTensorRT実装の両方に依存度が高く，debug頻度が高い．
+- 状態を持つ変換処理はdebug難易度が上がる．よってなるべく避けたい．
+
+### 3. `VadNode`で持つ
+
+- Nodeが状態を持つのはよくある話であり，素直
+- ただし，"can_bus"という，VADの世界の用語がNodeまで浸透するのはいただけない．
+
+## Decision Outcome
+
+- 「3. `VadNode`で持つ」を選択．
+    - 理由: `VadInterface`の責任範囲を守ること，(ROSとVAD TensorRTの２つの世界にまたがっているために)もっともbugが出やすい`VadInterface`を混沌から守ることが最優先と考えた．そのために，`VadNode`に，"can_bus"という，VADの世界の用語が浸透することを許容する．
+
+### Consequences
+
+- 2025/07/14: 「3. `VadNode`で持つ」を選択．

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -307,6 +307,7 @@ private:
   void enqueue(const std::string& head_name) {
     nets_["backbone"]->Enqueue(stream_);
     nets_[head_name]->Enqueue(stream_);
+    cudaDeviceSynchronize();
   }
 
   std::shared_ptr<nv::Tensor> save_prev_bev(const std::string& head_name) {

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -307,7 +307,7 @@ private:
   void enqueue(const std::string& head_name) {
     nets_["backbone"]->Enqueue(stream_);
     nets_[head_name]->Enqueue(stream_);
-    cudaDeviceSynchronize();
+    cudaStreamSynchronize(stream_);
   }
 
   std::shared_ptr<nv::Tensor> save_prev_bev(const std::string& head_name) {

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -307,7 +307,6 @@ private:
   void enqueue(const std::string& head_name) {
     nets_["backbone"]->Enqueue(stream_);
     nets_[head_name]->Enqueue(stream_);
-    cudaStreamSynchronize(stream_);
   }
 
   std::shared_ptr<nv::Tensor> save_prev_bev(const std::string& head_name) {

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -61,8 +61,8 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
 
 std::optional<Eigen::Matrix4f> VadInterface::lookup_base2cam(tf2_ros::Buffer & buffer, int32_t autoware_camera_id) const
 {
-  std::string target_frame = "camera" + std::to_string(autoware_camera_id) + "/camera_optical_link";
-  std::string source_frame = "base_link";
+  std::string target_frame = "base_link";
+  std::string source_frame = "camera" + std::to_string(autoware_camera_id) + "/camera_optical_link";
 
   try {
     geometry_msgs::msg::TransformStamped lookup_result =
@@ -83,8 +83,11 @@ std::optional<Eigen::Matrix4f> VadInterface::lookup_base2cam(tf2_ros::Buffer & b
         lookup_result.transform.rotation.y,
         lookup_result.transform.rotation.z);
     transform_matrix.block<3, 3>(0, 0) = q.toRotationMatrix();
-    
-    return transform_matrix;
+
+    // calculate the inverse transformation
+    Eigen::Matrix4f transform_matrix_inverse = transform_matrix.inverse();
+
+    return transform_matrix_inverse;
 
   } catch (const tf2::TransformException &ex) {
     RCLCPP_ERROR(rclcpp::get_logger("VadInterface"), "TF変換の取得に失敗: %s -> %s. Reason: %s",

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -138,6 +138,7 @@ convert_normalized_to_rgb(const std::vector<float> &normalized_data) {
 class VADNode : public rclcpp::Node {
 public:
   autoware::tensorrt_vad::VadInterfaceConfig vad_interface_config_;
+  std::vector<float> prev_can_bus_;
 
   VADNode(const std::vector<std::string> &yaml_config_paths)
       : Node("vad_node", createNodeOptions(yaml_config_paths)),
@@ -159,6 +160,10 @@ public:
         )
   {
 
+    std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
+    // default_can_bus: copy and convert
+    prev_can_bus_.clear();
+    for (auto v : default_can_bus) prev_can_bus_.push_back(static_cast<float>(v));
     // Publishers
     trajectory_publisher_ =
         this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
@@ -631,7 +636,7 @@ int main(int argc, char **argv) {
 
   
   // フレームごとに処理
-  std::vector<float> prev_can_bus;
+  std::vector<float> prev_can_bus = node->prev_can_bus_;
   for (int32_t frame_id = 1; frame_id <= vad_topic_data_list.size(); frame_id++) {
     std::string frame_dir = data_dir + std::to_string(frame_id) + "/";
 


### PR DESCRIPTION
# Description

- If we use rosbag made by autoware, we cannot use `buffer.lookupTransform("camera0/camera_optical_link", "base_link", tf2::TimePointZero);` to get transform_matrix, but we can use `buffer.lookupTransform("base_link", "camera0/camera_optical_link", tf2::TimePointZero);`
- So I changed the logic in `lookup_base2cam`.
- New logic is below;
   - 1. get transform from cam2base
   - 2. get inverse of cam2base. This is base2cam
   - 3. return base2cam.

# How this PR is tested

<details>
<summary>log for test in vad-trt</summary>

```sh
~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build dev/ns-ros-node-refactor/vad-interface/use-cam2base* ≡ autoware@dpc2308007 50s
❯ cd ../demo;../build/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1752468607.977924430] [vad_node]: VAD Node has been initialized
[INFO 1752468607.981836322] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1752468607.981868507] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1752468608.052595135] [vad_node]: -> engine: head_no_prev
[INFO 1752468608.052645121] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1752468608.266617681] [vad_node]: warm_up=20
[INFO] n_frames=30
Path is not a file: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag//output_bag.ns-0708
[INFO 1752468608.544529224] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/output_bag.ns-0708_0.db3' for READ_ONLY.
[INFO 1752468608.655911585] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1752468608.655972103] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=2 finished
publish trajectory[INFO] 2, cmd=2 finished
publish trajectory[INFO] 3, cmd=2 finished
publish trajectory[INFO] 4, cmd=2 finished
publish trajectory[INFO] 5, cmd=2 finished
publish trajectory[INFO] 6, cmd=2 finished
publish trajectory[INFO] 7, cmd=2 finished
publish trajectory[INFO] 8, cmd=2 finished
publish trajectory[INFO] 9, cmd=2 finished
publish trajectory[INFO] 10, cmd=2 finished
publish trajectory[INFO] 11, cmd=2 finished
publish trajectory[INFO] 12, cmd=2 finished
publish trajectorydet: -8.08834, -0.924591, -1.34317, 1.8819, 4.73548, 1.60459, 0.00860391, 1.94276e-05, 3.90064e-05, 0, 0.959663
det: 8.84364, 11.4066, -0.309545, 0.694822, 0.8312, 1.78013, -3.1286, -0.0161355, 1.47092, 8, 0.433175
det: -13.8689, 13.3048, -0.967812, 1.95628, 4.64862, 1.72945, -1.55743, 4.20909e-05, 6.5995e-05, 0, 0.937459
det: 9.14211, -15.5007, -1.83185, 0.722111, 0.870521, 1.83914, -3.10415, -0.00206712, 1.04062, 8, 0.673475
det: -13.0831, 8.23411, -0.82742, 0.669868, 0.859169, 1.81451, 0.00414772, -0.0112552, -1.33946, 8, 0.840452
det: -10.3616, -24.841, -2, 0.677065, 0.749911, 1.8549, -3.13702, -0.0123166, 0.74938, 8, 0.413085
det: 8.3368, 19.0722, 0.185008, 0.707245, 0.784375, 1.83915, 0.814291, -0.00298344, -0.844135, 8, 0.408253
det: -11.6099, -27.2925, -2, 0.651083, 0.762997, 1.83617, -0.00119819, -0.00788969, -1.27654, 8, 0.385602
det: 4.42792, 13.6955, -0.546876, 1.85134, 4.46188, 1.53316, -3.00078, -3.3635e-05, 2.34893e-05, 0, 0.965128
det: 8.21951, -14.5862, -1.41346, 0.650734, 0.840111, 1.80769, -3.13762, 0.000597659, 1.51255, 8, 0.360576
det: -3.64107, 25.4077, 0.325889, 1.94812, 4.77898, 1.73827, 0.146534, -0.273744, -3.89417, 0, 0.926187
det: 10.6456, -16.7269, -1.94683, 0.708887, 0.792232, 1.79765, -2.6228, 0.603408, 0.975134, 8, 0.739522
det: -8.49361, 27.5573, 0.466621, 2.02208, 4.77472, 1.76219, 1.46908, -0.000172792, 2.27132e-05, 0, 0.421464
det: 6.95453, -19.2432, -1.90096, 0.753938, 0.823065, 1.84771, 0.0451125, -0.00331103, -0.949795, 8, 0.823912
[INFO] 13, cmd=2 finished
publish trajectory[INFO] 14, cmd=2 finished
publish trajectory[INFO] 15, cmd=2 finished
publish trajectory[INFO] 16, cmd=2 finished
publish trajectory[INFO] 17, cmd=2 finished
publish trajectory[INFO] 18, cmd=2 finished
publish trajectory[INFO] 19, cmd=2 finished
publish trajectory[INFO] 20, cmd=2 finished
publish trajectory[INFO] 21, cmd=2 finished
publish trajectory[INFO] 22, cmd=2 finished
publish trajectory[INFO] 23, cmd=2 finished
publish trajectory[INFO] 24, cmd=2 finished
publish trajectory[INFO] 25, cmd=2 finished
publish trajectory[INFO] 26, cmd=2 finished
publish trajectory[INFO] 27, cmd=2 finished
publish trajectory[INFO] 28, cmd=2 finished
publish trajectory[INFO] 29, cmd=2 finished
```

</details>

<details>
<summary>log for test in autoware_tensorrt_vad</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ colcon build --symlink-install --cmake-args -DCMAKE
_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad
Starting >>> autoware_tensorrt_vad
[0.3s] [0/1 complete] [autoware_tensorrt_vad:build 39% - 0.2s]
Finished <<< autoware_tensorrt_vad [7.68s]                    

Summary: 1 package finished [7.82s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ 
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad && colcon test --packages-select autoware_tensorrt_vad --ctest-args -R test_vad_interface
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [0.11s]          

Summary: 1 package finished [0.26s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd ./build/autoware_tensorrt_vad/test_results/
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad/test_results$ cd ../
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_integration 
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (480 ms)
[----------] 1 test from VadIntegrationTest (480 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0390 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0280 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0280 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0280 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0370 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (388 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0020 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0eff10 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0eff10 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0eff10 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0f0000 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0efee0 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fffeb0efee0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (783 ms)
[----------] 2 tests from VadInferIntegrationTest (1171 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1654 ms total)
[  PASSED  ] 3 tests.
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ 
```

</details>
