### PR TITLE
feat(vad-trt): remove cudaDeviceSynchronize and use cudaStreamSynchronize

### DIFF
--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -307,6 +307,7 @@ private:
   void enqueue(const std::string& head_name) {
     nets_["backbone"]->Enqueue(stream_);
     nets_[head_name]->Enqueue(stream_);
+    cudaStreamSynchronize(stream_);
   }
 
   std::shared_ptr<nv::Tensor> save_prev_bev(const std::string& head_name) {
@@ -321,12 +322,12 @@ private:
     if (nets_.find(network_name) != nets_.end()) {
       // まずbindingsをクリア
       nets_[network_name]->bindings.clear();
-      cudaDeviceSynchronize();
+      cudaStreamSynchronize(stream_);
       
       // 次にNetオブジェクトを解放
       nets_[network_name].reset();
       nets_.erase(network_name);
-      cudaDeviceSynchronize();
+      cudaStreamSynchronize(stream_);
     }
   }
 


### PR DESCRIPTION
# Description

- remove `cudaDeviceSynchronize` and use `cudaStreamSynchronize`

# How this PR is tested

<details>
<summary>log for vad-trt</summary>

```sh
❯ cd ../demo;../build/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1752489308.518009152] [vad_node]: VAD Node has been initialized
[INFO 1752489308.522082418] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1752489308.522121012] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1752489308.596664254] [vad_node]: -> engine: head_no_prev
[INFO 1752489308.596750551] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1752489308.816725959] [vad_node]: warm_up=20
[INFO] n_frames=30
Path is not a file: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag//output_bag.ns-0708
[INFO 1752489309.098622737] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/output_bag.ns-0708_0.db3' for READ_ONLY.
[INFO 1752489309.216684689] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1752489309.216759956] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=2 finished
publish trajectory[INFO] 2, cmd=2 finished
publish trajectory[INFO] 3, cmd=2 finished
publish trajectory[INFO] 4, cmd=2 finished
publish trajectory[INFO] 5, cmd=2 finished
publish trajectory[INFO] 6, cmd=2 finished
publish trajectory[INFO] 7, cmd=2 finished
publish trajectory[INFO] 8, cmd=2 finished
publish trajectory[INFO] 9, cmd=2 finished
publish trajectory[INFO] 10, cmd=2 finished
publish trajectory[INFO] 11, cmd=2 finished
publish trajectory[INFO] 12, cmd=2 finished
publish trajectorydet: -8.08834, -0.924591, -1.34317, 1.8819, 4.73548, 1.60459, 0.00860391, 1.94276e-05, 3.90064e-05, 0, 0.959663
det: 8.84364, 11.4066, -0.309545, 0.694822, 0.8312, 1.78013, -3.1286, -0.0161355, 1.47092, 8, 0.433175
det: -13.8689, 13.3048, -0.967812, 1.95628, 4.64862, 1.72945, -1.55743, 4.20909e-05, 6.5995e-05, 0, 0.937459
det: 9.14211, -15.5007, -1.83185, 0.722111, 0.870521, 1.83914, -3.10415, -0.00206712, 1.04062, 8, 0.673475
det: -13.0831, 8.23411, -0.82742, 0.669868, 0.859169, 1.81451, 0.00414772, -0.0112552, -1.33946, 8, 0.840452
det: -10.3616, -24.841, -2, 0.677065, 0.749911, 1.8549, -3.13702, -0.0123166, 0.74938, 8, 0.413085
det: 8.3368, 19.0722, 0.185008, 0.707245, 0.784375, 1.83915, 0.814291, -0.00298344, -0.844135, 8, 0.408253
det: -11.6099, -27.2925, -2, 0.651083, 0.762997, 1.83617, -0.00119819, -0.00788969, -1.27654, 8, 0.385602
det: 4.42792, 13.6955, -0.546876, 1.85134, 4.46188, 1.53316, -3.00078, -3.3635e-05, 2.34893e-05, 0, 0.965128
det: 8.21951, -14.5862, -1.41346, 0.650734, 0.840111, 1.80769, -3.13762, 0.000597659, 1.51255, 8, 0.360576
det: -3.64107, 25.4077, 0.325889, 1.94812, 4.77898, 1.73827, 0.146534, -0.273744, -3.89417, 0, 0.926187
det: 10.6456, -16.7269, -1.94683, 0.708887, 0.792232, 1.79765, -2.6228, 0.603408, 0.975134, 8, 0.739522
det: -8.49361, 27.5573, 0.466621, 2.02208, 4.77472, 1.76219, 1.46908, -0.000172792, 2.27132e-05, 0, 0.421464
det: 6.95453, -19.2432, -1.90096, 0.753938, 0.823065, 1.84771, 0.0451125, -0.00331103, -0.949795, 8, 0.823912
[INFO] 13, cmd=2 finished
publish trajectory[INFO] 14, cmd=2 finished
publish trajectory[INFO] 15, cmd=2 finished
publish trajectory[INFO] 16, cmd=2 finished
publish trajectory[INFO] 17, cmd=2 finished
publish trajectory[INFO] 18, cmd=2 finished
publish trajectory[INFO] 19, cmd=2 finished
publish trajectory[INFO] 20, cmd=2 finished
publish trajectory[INFO] 21, cmd=2 finished
publish trajectory[INFO] 22, cmd=2 finished
publish trajectory[INFO] 23, cmd=2 finished
publish trajectory[INFO] 24, cmd=2 finished
publish trajectory[INFO] 25, cmd=2 finished
publish trajectory[INFO] 26, cmd=2 finished
publish trajectory[INFO] 27, cmd=2 finished
publish trajectory[INFO] 28, cmd=2 finished
publish trajectory[INFO] 29, cmd=2 finished

~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/test/build dev/ns-ros-node_refactor/remove-device-sync* ≡ autoware@dpc2308007 10s
❯ ./vad_tests
Running main() from ./googletest/src/gtest_main.cc
[==========] Running 8 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from VadModelTest
[ RUN      ] VadModelTest.VadInputDataStructure
[       OK ] VadModelTest.VadInputDataStructure (15 ms)
[ RUN      ] VadModelTest.VadOutputDataStructure
[       OK ] VadModelTest.VadOutputDataStructure (0 ms)
[ RUN      ] VadModelTest.VadConfigStructure
[       OK ] VadModelTest.VadConfigStructure (0 ms)
[ RUN      ] VadModelTest.NetworkParamClass
[       OK ] VadModelTest.NetworkParamClass (0 ms)
[----------] 4 tests from VadModelTest (15 ms total)

[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (551 ms)
[----------] 1 test from VadIntegrationTest (551 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d5c0 "loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d5c0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d5c0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d5c0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d670 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (374 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d4c0 "loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d4c0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d4c0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d4c0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d570 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d530 "-> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7fff44b0d530 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (793 ms)
[----------] 2 tests from VadInferIntegrationTest (1167 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 4 test suites ran. (1735 ms total)
[  PASSED  ] 8 tests.
```

</details>

<details>
<summary>log of autoware_tensorrt_vad</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ colcon build --symlink-install --cmake-args -DCMAK
E_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [7.86s]                     

Summary: 1 package finished [8.00s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad && colcon test --packages-select autoware_tensorrt_vad --ctest-args -R test_vad_interface
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [0.11s]          

Summary: 1 package finished [0.27s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd build/autoware_tensorrt_vad/
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_integration 
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (566 ms)
[----------] 1 test from VadIntegrationTest (566 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c1d60 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c1c50 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c1c50 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c1c50 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c1d40 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (380 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c19f0 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c18e0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c18e0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c18e0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c19d0 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c18b0 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffc360c18b0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (785 ms)
[----------] 2 tests from VadInferIntegrationTest (1165 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1731 ms total)
[  PASSED  ] 3 tests.
```

</details>