### PR TITLE
feat(vad-trt): add candidate trajectory output

### DIFF
--- a/AV-Solutions/vad-trt/app/.gitignore
+++ b/AV-Solutions/vad-trt/app/.gitignore
@@ -3,3 +3,6 @@ test/build*/
 lib/cuOSD/
 lib/stb/
 *.bin
+log/
+install/
+msgs_ws/

--- a/AV-Solutions/vad-trt/app/CMakeLists.txt
+++ b/AV-Solutions/vad-trt/app/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_FLAGS "-fPIC -g -O0")
 set(CMAKE_CXX_FLAGS "-fPIC -g -O0")
 
+# msgs_wsのインストールパスをCMAKE_PREFIX_PATHに追加
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/msgs_ws/install")
+
 # ROS2の依存関係を追加
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -16,9 +19,12 @@ find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(autoware_perception_msgs REQUIRED)
+find_package(autoware_internal_planning_msgs REQUIRED)
 find_package(autoware_planning_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 
 # Find CUDA package first
@@ -70,6 +76,7 @@ include_directories(
     ${CUDA_INCLUDE_DIRS}
     ${CUDA_TOOLKIT_ROOT_DIR}/include
     ${TENSORRT_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/msgs_ws/install/autoware_internal_planning_msgs/include
 )
 
 # Common link directories
@@ -123,6 +130,7 @@ target_link_libraries(${APP}_app
     ${eigen3_cmake_module_LIBRARIES}
     ${Eigen3_LIBRARIES}
     ${autoware_perception_msgs_LIBRARIES}
+    ${autoware_internal_planning_msgs_LIBRARIES}
     ${autoware_planning_msgs_LIBRARIES}
     ${geometry_msgs_LIBRARIES}
     ${rosbag2_cpp_LIBRARIES}
@@ -137,6 +145,7 @@ target_include_directories(${APP}_app PUBLIC
     ${eigen3_cmake_module_INCLUDE_DIRS}
     ${Eigen3_INCLUDE_DIRS}
     ${autoware_perception_msgs_INCLUDE_DIRS}
+    ${autoware_internal_planning_msgs_INCLUDE_DIRS}
     ${autoware_planning_msgs_INCLUDE_DIRS}
     ${geometry_msgs_INCLUDE_DIRS}
     ${rosbag2_cpp_INCLUDE_DIRS}

--- a/AV-Solutions/vad-trt/app/CMakeLists.txt
+++ b/AV-Solutions/vad-trt/app/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(autoware_planning_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(unique_identifier_msgs REQUIRED)
+find_package(autoware_utils_uuid REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 
@@ -154,4 +155,22 @@ target_include_directories(${APP}_app PUBLIC
 # インストール設定
 install(TARGETS ${PROJECT_NAME}
     DESTINATION lib/${PROJECT_NAME}
+)
+
+# ament_target_dependenciesでROS2の依存関係を設定
+ament_target_dependencies(${APP}_app
+    rclcpp
+    tf2_ros
+    tf2_eigen
+    eigen3_cmake_module
+    Eigen3
+    sensor_msgs
+    autoware_perception_msgs
+    autoware_internal_planning_msgs
+    autoware_planning_msgs
+    geometry_msgs
+    rosbag2_cpp
+    unique_identifier_msgs
+    autoware_utils_uuid
+    std_msgs
 )

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -37,6 +37,8 @@
                 -1.0, 0.0, 0.0, 0.0,
                  0.0, 0.0, 1.0, 0.0,
                  0.0, 0.0, 0.0, 1.0]
+      # params for output
+      trajectory_timestep: 1.0 # [s]
     model_params:
       # Engine paths with hierarchical structure
       nets:

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -84,6 +84,10 @@ struct VadOutputData
   // planning[0,1] = 1st point (x,y), planning[2,3] = 2nd point (x,y), ...
   std::vector<float> predicted_trajectory_{};  // size: 12 (6 points * 2 coordinates)
 
+  // 複数のコマンドに対応した予測軌道のマップ
+  // key: command index (int32_t), value: trajectory (std::vector<float>)
+  std::map<int32_t, std::vector<float>> predicted_trajectories_{};
+
   // // 検出されたオブジェクト
   // std::vector<std::vector<float>> detected_objects_{};
 
@@ -384,7 +388,24 @@ private:
       planning[i * 2 + 1] += planning[(i-1) * 2 + 1];
     }
     
-    return VadOutputData{planning};
+    // Extract all trajectories for all 3 commands
+    std::map<int32_t, std::vector<float>> all_trajectories;
+    for (int32_t command_idx = 0; command_idx < 3; command_idx++) {
+      std::vector<float> trajectory(
+          ego_fut_preds.begin() + command_idx * 12,
+          ego_fut_preds.begin() + (command_idx + 1) * 12
+      );
+      
+      // cumsum to build trajectory in 3d space
+      for (int32_t i = 1; i < 6; i++) {
+        trajectory[i * 2] += trajectory[(i-1) * 2];
+        trajectory[i * 2 + 1] += trajectory[(i-1) * 2 + 1];
+      }
+      
+      all_trajectories[command_idx] = trajectory;
+    }
+    
+    return VadOutputData{planning, all_trajectories};
   }
 };
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -23,6 +23,7 @@
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
@@ -66,6 +67,7 @@ private:
 
   // Publishers
   rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr trajectory_pub_{nullptr};
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr candidate_trajectories_pub_{nullptr};
   // rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr detected_objects_pub_{nullptr};
 
   // 推論を実行するメソッド

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -24,6 +24,10 @@
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/generator_info.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_utils_uuid</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>geometry_msgs</depend>
   <depend>libeigen3-dev</depend>

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
@@ -12,6 +12,7 @@
   <!-- ROS2 core dependencies -->
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>geometry_msgs</depend>
   <depend>libeigen3-dev</depend>

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -209,7 +209,6 @@ public:
   }
 
   void publishTrajectory(const std::vector<float> &planning) {
-    // 元の Trajectory メッセージを作成
     auto trajectory_msg =
         std::make_unique<autoware_planning_msgs::msg::Trajectory>();
 
@@ -257,11 +256,9 @@ public:
       trajectory_msg->points.push_back(point);
     }
 
-    // 元のTrajectoryメッセージのヘッダーを設定
     trajectory_msg->header.stamp = this->now();
     trajectory_msg->header.frame_id = "base_link";
 
-    // 両方のメッセージを発行
     trajectory_publisher_->publish(std::move(trajectory_msg));
   }
 

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -40,7 +40,12 @@
 #include <Eigen/Dense>
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/generator_info.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -169,6 +174,10 @@ public:
         this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
             "/planning/vad/trajectory", rclcpp::QoS(1));
 
+    candidate_trajectories_publisher_ =
+        this->create_publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
+            "/planning/vad/trajectories", rclcpp::QoS(1));
+
     objects_publisher_ =
         this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
             "/perception/object_recognition/detection/vad/objects",
@@ -200,8 +209,26 @@ public:
   }
 
   void publishTrajectory(const std::vector<float> &planning) {
+    // 元の Trajectory メッセージを作成
     auto trajectory_msg =
         std::make_unique<autoware_planning_msgs::msg::Trajectory>();
+
+    // CandidateTrajectories メッセージを作成
+    auto candidate_trajectories_msg =
+        std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
+
+    // 単一のCandidateTrajectoryを作成
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    
+    // ヘッダーを設定
+    candidate_trajectory.header.stamp = this->now();
+    candidate_trajectory.header.frame_id = "map";
+    
+    // generator_idを設定（デフォルトのUUID）
+    // UUIDは通常は16バイトですが、ここでは簡単のため0で初期化
+    for (int i = 0; i < 16; ++i) {
+      candidate_trajectory.generator_id.uuid[i] = 0;
+    }
 
     for (size_t i = 0; i < planning.size(); i += 2) {
       autoware_planning_msgs::msg::TrajectoryPoint point;
@@ -224,13 +251,29 @@ public:
       point.acceleration_mps2 = 0.0;
       point.heading_rate_rps = 0.0;
 
+      // 両方のメッセージに同じポイントを追加
       trajectory_msg->points.push_back(point);
+      candidate_trajectory.points.push_back(point);
     }
 
+    // 元のTrajectoryメッセージのヘッダーを設定
     trajectory_msg->header.stamp = this->now();
     trajectory_msg->header.frame_id = "map";
 
+    // CandidateTrajectoryをCandidateTrajectories配列に追加
+    candidate_trajectories_msg->candidate_trajectories.push_back(candidate_trajectory);
+
+    // GeneratorInfoを追加（オプション）
+    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+    for (int i = 0; i < 16; ++i) {
+      generator_info.generator_id.uuid[i] = 0;
+    }
+    generator_info.generator_name.data = "vad_generator";
+    candidate_trajectories_msg->generator_info.push_back(generator_info);
+
+    // 両方のメッセージを発行
     trajectory_publisher_->publish(std::move(trajectory_msg));
+    candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
   }
 
   void
@@ -272,6 +315,8 @@ public:
 private:
   rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr
       trajectory_publisher_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr
+      candidate_trajectories_publisher_;
   rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
       objects_publisher_;
   std::vector<

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -44,7 +44,7 @@
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
 #include <autoware_internal_planning_msgs/msg/generator_info.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
-#include <unique_identifier_msgs/msg/uuid.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
@@ -213,22 +213,6 @@ public:
     auto trajectory_msg =
         std::make_unique<autoware_planning_msgs::msg::Trajectory>();
 
-    // CandidateTrajectories メッセージを作成
-    auto candidate_trajectories_msg =
-        std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
-
-    // 単一のCandidateTrajectoryを作成
-    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
-    
-    // ヘッダーを設定
-    candidate_trajectory.header.stamp = this->now();
-    candidate_trajectory.header.frame_id = "map";
-    
-    // generator_idを設定（デフォルトのUUID）
-    // UUIDは通常は16バイトですが、ここでは簡単のため0で初期化
-    for (int i = 0; i < 16; ++i) {
-      candidate_trajectory.generator_id.uuid[i] = 0;
-    }
 
     for (size_t i = 0; i < planning.size(); i += 2) {
       autoware_planning_msgs::msg::TrajectoryPoint point;
@@ -253,27 +237,15 @@ public:
 
       // 両方のメッセージに同じポイントを追加
       trajectory_msg->points.push_back(point);
-      candidate_trajectory.points.push_back(point);
     }
 
     // 元のTrajectoryメッセージのヘッダーを設定
     trajectory_msg->header.stamp = this->now();
     trajectory_msg->header.frame_id = "map";
 
-    // CandidateTrajectoryをCandidateTrajectories配列に追加
-    candidate_trajectories_msg->candidate_trajectories.push_back(candidate_trajectory);
-
-    // GeneratorInfoを追加（オプション）
-    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
-    for (int i = 0; i < 16; ++i) {
-      generator_info.generator_id.uuid[i] = 0;
-    }
-    generator_info.generator_name.data = "vad_generator";
-    candidate_trajectories_msg->generator_info.push_back(generator_info);
 
     // 両方のメッセージを発行
     trajectory_publisher_->publish(std::move(trajectory_msg));
-    candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
   }
 
   void publishTrajectories(const std::map<int32_t, std::vector<float>> &trajectories_map) {
@@ -289,12 +261,8 @@ public:
       candidate_trajectory.header.stamp = this->now();
       candidate_trajectory.header.frame_id = "map";
       
-      // generator_idを設定（コマンドインデックスベース）
-      for (int i = 0; i < 16; ++i) {
-        candidate_trajectory.generator_id.uuid[i] = 0;
-      }
-      // コマンドインデックスをUUIDの最初のバイトに設定
-      candidate_trajectory.generator_id.uuid[0] = static_cast<uint8_t>(command_idx);
+      // generator_idを設定（ユニークなUUID）
+      candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
 
       for (size_t i = 0; i < trajectory.size(); i += 2) {
         autoware_planning_msgs::msg::TrajectoryPoint point;
@@ -324,11 +292,8 @@ public:
 
       // 各コマンドのGeneratorInfoを追加
       autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
-      for (int i = 0; i < 16; ++i) {
-        generator_info.generator_id.uuid[i] = 0;
-      }
-      generator_info.generator_id.uuid[0] = static_cast<uint8_t>(command_idx);
-      generator_info.generator_name.data = "vad_generator_cmd_" + std::to_string(command_idx);
+      generator_info.generator_id = autoware_utils_uuid::generate_uuid();
+      generator_info.generator_name.data = "autoware_tensorrt_vad_cmd_" + std::to_string(command_idx);
       candidate_trajectories_msg->generator_info.push_back(generator_info);
     }
 

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -45,7 +45,6 @@
 #include <autoware_internal_planning_msgs/msg/generator_info.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
-#include <std_msgs/msg/string.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -162,7 +162,8 @@ public:
           declare_parameter<std::vector<double>>("interface_params.image_normalization_param_std"),
           declare_parameter<std::vector<double>>("interface_params.vad2base"),
           declare_parameter<std::vector<int64_t>>("interface_params.autoware_to_vad_camera_mapping")
-        )
+        ),
+        trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0))
   {
 
     std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
@@ -213,6 +214,19 @@ public:
     auto trajectory_msg =
         std::make_unique<autoware_planning_msgs::msg::Trajectory>();
 
+    // 0秒目の点 (0,0) を追加
+    autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+    initial_point.pose.position.x = 0.0;
+    initial_point.pose.position.y = 0.0;
+    initial_point.pose.position.z = 0.0;
+    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+    initial_point.longitudinal_velocity_mps = 0.0;
+    initial_point.lateral_velocity_mps = 0.0;
+    initial_point.acceleration_mps2 = 0.0;
+    initial_point.heading_rate_rps = 0.0;
+    initial_point.time_from_start.sec = 0;
+    initial_point.time_from_start.nanosec = 0;
+    trajectory_msg->points.push_back(initial_point);
 
     for (size_t i = 0; i < planning.size(); i += 2) {
       autoware_planning_msgs::msg::TrajectoryPoint point;
@@ -235,14 +249,18 @@ public:
       point.acceleration_mps2 = 0.0;
       point.heading_rate_rps = 0.0;
 
-      // 両方のメッセージに同じポイントを追加
+      // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+      size_t point_index = i / 2;
+      double time_sec = (point_index + 1) * trajectory_timestep_;
+      point.time_from_start.sec = static_cast<int32_t>(time_sec);
+      point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
       trajectory_msg->points.push_back(point);
     }
 
     // 元のTrajectoryメッセージのヘッダーを設定
     trajectory_msg->header.stamp = this->now();
-    trajectory_msg->header.frame_id = "map";
-
+    trajectory_msg->header.frame_id = "base_link";
 
     // 両方のメッセージを発行
     trajectory_publisher_->publish(std::move(trajectory_msg));
@@ -259,10 +277,24 @@ public:
       
       // ヘッダーを設定
       candidate_trajectory.header.stamp = this->now();
-      candidate_trajectory.header.frame_id = "map";
+      candidate_trajectory.header.frame_id = "base_link";
       
       // generator_idを設定（ユニークなUUID）
       candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
+
+      // 0秒目の点 (0,0) を追加
+      autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+      initial_point.pose.position.x = 0.0;
+      initial_point.pose.position.y = 0.0;
+      initial_point.pose.position.z = 0.0;
+      initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+      initial_point.longitudinal_velocity_mps = 0.0;
+      initial_point.lateral_velocity_mps = 0.0;
+      initial_point.acceleration_mps2 = 0.0;
+      initial_point.heading_rate_rps = 0.0;
+      initial_point.time_from_start.sec = 0;
+      initial_point.time_from_start.nanosec = 0;
+      candidate_trajectory.points.push_back(initial_point);
 
       for (size_t i = 0; i < trajectory.size(); i += 2) {
         autoware_planning_msgs::msg::TrajectoryPoint point;
@@ -284,6 +316,12 @@ public:
         point.lateral_velocity_mps = 0.0;
         point.acceleration_mps2 = 0.0;
         point.heading_rate_rps = 0.0;
+
+        // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+        size_t point_index = i / 2;
+        double time_sec = (point_index + 1) * trajectory_timestep_;
+        point.time_from_start.sec = static_cast<int32_t>(time_sec);
+        point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
 
         candidate_trajectory.points.push_back(point);
       }
@@ -349,6 +387,9 @@ private:
 
   // VadConfig
   autoware::tensorrt_vad::VadConfig vad_config_;
+
+  // trajectory_timestep parameter
+  double trajectory_timestep_;
 
   // yamlファイルのパスからNodeOptionsを作成する静的関数
   static rclcpp::NodeOptions

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -276,6 +276,65 @@ public:
     candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
   }
 
+  void publishTrajectories(const std::map<int32_t, std::vector<float>> &trajectories_map) {
+    // CandidateTrajectories メッセージを作成
+    auto candidate_trajectories_msg =
+        std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
+
+    // 各コマンドの軌道をCandidateTrajectoryとして追加
+    for (const auto& [command_idx, trajectory] : trajectories_map) {
+      autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+      
+      // ヘッダーを設定
+      candidate_trajectory.header.stamp = this->now();
+      candidate_trajectory.header.frame_id = "map";
+      
+      // generator_idを設定（コマンドインデックスベース）
+      for (int i = 0; i < 16; ++i) {
+        candidate_trajectory.generator_id.uuid[i] = 0;
+      }
+      // コマンドインデックスをUUIDの最初のバイトに設定
+      candidate_trajectory.generator_id.uuid[0] = static_cast<uint8_t>(command_idx);
+
+      for (size_t i = 0; i < trajectory.size(); i += 2) {
+        autoware_planning_msgs::msg::TrajectoryPoint point;
+
+        point.pose.position.x = trajectory[i + 1];
+        point.pose.position.y = -trajectory[i];
+        point.pose.position.z = 0.0;
+
+        if (i + 2 < trajectory.size()) {
+          float ns_dx = trajectory[i + 2] - trajectory[i];
+          float ns_dy = trajectory[i + 3] - trajectory[i + 1];
+          float aw_dx = ns_dy;  // Autowareの座標系に変換
+          float aw_dy = -ns_dx; // Autowareの座標系に変換
+          float yaw = std::atan2(aw_dy, aw_dx);
+          point.pose.orientation = createQuaternionFromYaw(yaw);
+        }
+
+        point.longitudinal_velocity_mps = 0.0;
+        point.lateral_velocity_mps = 0.0;
+        point.acceleration_mps2 = 0.0;
+        point.heading_rate_rps = 0.0;
+
+        candidate_trajectory.points.push_back(point);
+      }
+
+      candidate_trajectories_msg->candidate_trajectories.push_back(candidate_trajectory);
+
+      // 各コマンドのGeneratorInfoを追加
+      autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+      for (int i = 0; i < 16; ++i) {
+        generator_info.generator_id.uuid[i] = 0;
+      }
+      generator_info.generator_id.uuid[0] = static_cast<uint8_t>(command_idx);
+      generator_info.generator_name.data = "vad_generator_cmd_" + std::to_string(command_idx);
+      candidate_trajectories_msg->generator_info.push_back(generator_info);
+    }
+
+    candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
+  }
+
   void
   publishDetectedObjects(const std::vector<std::vector<float>> &detections) {
     auto objects_msg =
@@ -732,6 +791,10 @@ int main(int argc, char **argv) {
     // pred -> frame.planning
     frame.planning = vad_output_data.predicted_trajectory_;
     node->publishTrajectory(frame.planning);
+    
+    // publish all trajectories as CandidateTrajectories
+    node->publishTrajectories(vad_output_data.predicted_trajectories_);
+    
     printf("publish trajectory");
     rclcpp::spin_some(node);
 


### PR DESCRIPTION
# Description

- Use candidate trajectories

# How this PR is tested

<details>
<summary>log of test in vad-trt</summary>

```sh
❯ ../build/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1752636585.037816561] [vad_node]: VAD Node has been initialized
[INFO 1752636585.041654737] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1752636585.041687644] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1752636585.113758285] [vad_node]: -> engine: head_no_prev
[INFO 1752636585.113802047] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1752636585.326990562] [vad_node]: warm_up=20
[INFO] n_frames=30
Path is not a file: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag//output_bag.ns-0708
[INFO 1752636585.609015104] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/output_bag.ns-0708_0.db3' for READ_ONLY.
[INFO 1752636585.721198040] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1752636585.721272869] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=2 finished
publish trajectory[INFO] 2, cmd=2 finished
publish trajectory[INFO] 3, cmd=2 finished
publish trajectory[INFO] 4, cmd=2 finished
publish trajectory[INFO] 5, cmd=2 finished
publish trajectory[INFO] 6, cmd=2 finished
publish trajectory[INFO] 7, cmd=2 finished
publish trajectory[INFO] 8, cmd=2 finished
publish trajectory[INFO] 9, cmd=2 finished
publish trajectory[INFO] 10, cmd=2 finished
publish trajectory[INFO] 11, cmd=2 finished
publish trajectory[INFO] 12, cmd=2 finished
publish trajectorydet: -8.08834, -0.924591, -1.34317, 1.8819, 4.73548, 1.60459, 0.00860391, 1.94276e-05, 3.90064e-05, 0, 0.959663
det: 8.84364, 11.4066, -0.309545, 0.694822, 0.8312, 1.78013, -3.1286, -0.0161355, 1.47092, 8, 0.433175
det: -13.8689, 13.3048, -0.967812, 1.95628, 4.64862, 1.72945, -1.55743, 4.20909e-05, 6.5995e-05, 0, 0.937459
det: 9.14211, -15.5007, -1.83185, 0.722111, 0.870521, 1.83914, -3.10415, -0.00206712, 1.04062, 8, 0.673475
det: -13.0831, 8.23411, -0.82742, 0.669868, 0.859169, 1.81451, 0.00414772, -0.0112552, -1.33946, 8, 0.840452
det: -10.3616, -24.841, -2, 0.677065, 0.749911, 1.8549, -3.13702, -0.0123166, 0.74938, 8, 0.413085
det: 8.3368, 19.0722, 0.185008, 0.707245, 0.784375, 1.83915, 0.814291, -0.00298344, -0.844135, 8, 0.408253
det: -11.6099, -27.2925, -2, 0.651083, 0.762997, 1.83617, -0.00119819, -0.00788969, -1.27654, 8, 0.385602
det: 4.42792, 13.6955, -0.546876, 1.85134, 4.46188, 1.53316, -3.00078, -3.3635e-05, 2.34893e-05, 0, 0.965128
det: 8.21951, -14.5862, -1.41346, 0.650734, 0.840111, 1.80769, -3.13762, 0.000597659, 1.51255, 8, 0.360576
det: -3.64107, 25.4077, 0.325889, 1.94812, 4.77898, 1.73827, 0.146534, -0.273744, -3.89417, 0, 0.926187
det: 10.6456, -16.7269, -1.94683, 0.708887, 0.792232, 1.79765, -2.6228, 0.603408, 0.975134, 8, 0.739522
det: -8.49361, 27.5573, 0.466621, 2.02208, 4.77472, 1.76219, 1.46908, -0.000172792, 2.27132e-05, 0, 0.421464
det: 6.95453, -19.2432, -1.90096, 0.753938, 0.823065, 1.84771, 0.0451125, -0.00331103, -0.949795, 8, 0.823912
[INFO] 13, cmd=2 finished
publish trajectory[INFO] 14, cmd=2 finished
publish trajectory[INFO] 15, cmd=2 finished
publish trajectory[INFO] 16, cmd=2 finished
publish trajectory[INFO] 17, cmd=2 finished
publish trajectory[INFO] 18, cmd=2 finished
publish trajectory[INFO] 19, cmd=2 finished
publish trajectory[INFO] 20, cmd=2 finished
publish trajectory[INFO] 21, cmd=2 finished
publish trajectory[INFO] 22, cmd=2 finished
publish trajectory[INFO] 23, cmd=2 finished
publish trajectory[INFO] 24, cmd=2 finished
publish trajectory[INFO] 25, cmd=2 finished
publish trajectory[INFO] 26, cmd=2 finished
publish trajectory[INFO] 27, cmd=2 finished
publish trajectory[INFO] 28, cmd=2 finished
publish trajectory[INFO] 29, cmd=2 finished

```

</details>

<details>
<summary>log of test in autoware_tensorrt_vad</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ colcon build --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [5.90s]                     

Summary: 1 package finished [6.10s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad && colcon test --packages-select autoware_tensorrt_vad --ctest-args -R test_vad_interface
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [0.28s]          

Summary: 1 package finished [0.48s]

autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_integration 
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (574 ms)
[----------] 1 test from VadIntegrationTest (574 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744e190 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744e080 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744e080 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744e080 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744e170 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (388 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744ddb0 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dca0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dca0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dca0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dd90 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dc40 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffe0744dc40 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (798 ms)
[----------] 2 tests from VadInferIntegrationTest (1186 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1769 ms total)
[  PASSED  ] 3 tests.
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
```

</details>

<details>
<summary>ros2 topic echo /planning/vad/trajectories --once</summary>

```sh

autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/msgs_ws/src/autoware_utils_uuid$ ros2 topic echo /planning/vad/trajectories --once
candidate_trajectories:
- header:
    stamp:
      sec: 1752635619
      nanosec: 838402271
    frame_id: base_link
  generator_id:
    uuid:
    - 160
    - 197
    - 198
    - 98
    - 225
    - 112
    - 137
    - 139
    - 70
    - 139
    - 69
    - 139
    - 169
    - 120
    - 129
    - 52
  points:
  - time_from_start:
      sec: 0
      nanosec: 0
    pose:
      position:
        x: 0.0
        y: 0.0
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 1
      nanosec: 0
    pose:
      position:
        x: 5.5517578125
        y: -0.14419981837272644
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.022860830103773957
        w: 0.9997386570734206
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 2
      nanosec: 0
    pose:
      position:
        x: 11.133862495422363
        y: -0.39962318539619446
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.034460798356129765
        w: 0.9994060503002061
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 3
      nanosec: 0
    pose:
      position:
        x: 16.753910064697266
        y: -0.7876573801040649
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.045518486379897194
        w: 0.998963496529119
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 4
      nanosec: 0
    pose:
      position:
        x: 22.39076042175293
        y: -1.3024203777313232
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.05719648406031891
        w: 0.9983629411246883
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 5
      nanosec: 0
    pose:
      position:
        x: 28.034160614013672
        y: -1.9511735439300537
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.06639393386346902
        w: 0.9977934884264045
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 6
      nanosec: 0
    pose:
      position:
        x: 33.66851806640625
        y: -2.7043371200561523
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
- header:
    stamp:
      sec: 1752635619
      nanosec: 838421310
    frame_id: base_link
  generator_id:
    uuid:
    - 249
    - 25
    - 151
    - 163
    - 218
    - 155
    - 134
    - 207
    - 33
    - 68
    - 25
    - 245
    - 163
    - 173
    - 188
    - 193
  points:
  - time_from_start:
      sec: 0
      nanosec: 0
    pose:
      position:
        x: 0.0
        y: 0.0
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 1
      nanosec: 0
    pose:
      position:
        x: 5.616230010986328
        y: 0.043059028685092926
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.010348372786508919
        w: 0.9999464541567571
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 2
      nanosec: 0
    pose:
      position:
        x: 11.357379913330078
        y: 0.16190123558044434
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.029271794311481053
        w: 0.9995714892181481
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 3
      nanosec: 0
    pose:
      position:
        x: 17.08742332458496
        y: 0.4977903962135315
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.03510566541945695
        w: 0.9993836061570438
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 4
      nanosec: 0
    pose:
      position:
        x: 22.85736846923828
        y: 0.9036566019058228
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.04948562174553699
        w: 0.9987748361069464
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 5
      nanosec: 0
    pose:
      position:
        x: 28.67915916442871
        y: 1.4819729328155518
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.06140297592042475
        w: 0.9981130569971098
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 6
      nanosec: 0
    pose:
      position:
        x: 34.48714828491211
        y: 2.199291706085205
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
- header:
    stamp:
      sec: 1752635619
      nanosec: 838437898
    frame_id: base_link
  generator_id:
    uuid:
    - 3
    - 197
    - 0
    - 51
    - 178
    - 80
    - 25
    - 201
    - 47
    - 38
    - 248
    - 156
    - 157
    - 194
    - 60
    - 55
  points:
  - time_from_start:
      sec: 0
      nanosec: 0
    pose:
      position:
        x: 0.0
        y: 0.0
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 1
      nanosec: 0
    pose:
      position:
        x: 5.508077144622803
        y: -0.051305778324604034
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.005691167909428404
        w: 0.9999838051727772
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 2
      nanosec: 0
    pose:
      position:
        x: 11.064847946166992
        y: -0.11455788463354111
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.007817953345826491
        w: 0.9999694393357641
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 3
      nanosec: 0
    pose:
      position:
        x: 16.65799331665039
        y: -0.2020197957754135
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.007723568515399507
        w: 0.999970172799863
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 4
      nanosec: 0
    pose:
      position:
        x: 22.285675048828125
        y: -0.2889591455459595
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.00814668856372915
        w: 0.9999668151821067
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 5
      nanosec: 0
    pose:
      position:
        x: 27.960891723632812
        y: -0.3814367949962616
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: -0.010119635178215023
        w: 0.9999487951809631
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
  - time_from_start:
      sec: 6
      nanosec: 0
    pose:
      position:
        x: 33.66401290893555
        y: -0.49688154458999634
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    longitudinal_velocity_mps: 0.0
    lateral_velocity_mps: 0.0
    acceleration_mps2: 0.0
    heading_rate_rps: 0.0
    front_wheel_angle_rad: 0.0
    rear_wheel_angle_rad: 0.0
generator_info:
- generator_id:
    uuid:
    - 28
    - 61
    - 160
    - 5
    - 29
    - 171
    - 28
    - 65
    - 79
    - 92
    - 82
    - 248
    - 4
    - 154
    - 1
    - 163
  generator_name:
    data: autoware_tensorrt_vad_cmd_0
- generator_id:
    uuid:
    - 178
    - 204
    - 69
    - 136
    - 250
    - 148
    - 223
    - 240
    - 151
    - 150
    - 88
    - 230
    - 248
    - 49
    - 38
    - 126
  generator_name:
    data: autoware_tensorrt_vad_cmd_1
- generator_id:
    uuid:
    - 69
    - 84
    - 22
    - 41
    - 86
    - 236
    - 70
    - 146
    - 138
    - 61
    - 229
    - 25
    - 223
    - 251
    - 239
    - 81
  generator_name:
    data: autoware_tensorrt_vad_cmd_2
---


```

</details>