### PR TITLE
feat(autoware_tensorrt_vad): add VAD ROS Node

### DIFF
--- a/AV-Solutions/vad-trt/app/.gitignore
+++ b/AV-Solutions/vad-trt/app/.gitignore
@@ -6,3 +6,4 @@ lib/stb/
 log/
 install/
 msgs_ws/
+autoware_tensorrt_vad/script

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -2,14 +2,14 @@
   ros__parameters:
     interface_params:
       # # awsim
-      # input_image_width: 1920
-      # input_image_height: 1080
+      input_image_width: 1920
+      input_image_height: 1080
       # # autoware xx1
       # input_image_width: 1466
       # input_image_height: 1122
       # nuScenes
-      input_image_width: 1653
-      input_image_height: 940
+      # input_image_width: 1653
+      # input_image_height: 940
       target_image_width: 640
       target_image_height: 384
       point_cloud_range: [-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]
@@ -33,6 +33,12 @@
                                        1, 3, # BACK
                                        3, 4, # BACK_LEFT
                                        5, 5] # BACK_RIGHT
+      # # nuScenes
+      # vad2base: [0.0, 1.0, 0.0, 0.0,
+      #           -1.0, 0.0, 0.0, 0.0,
+      #            0.0, 0.0, 1.0, 1.2,
+      #            0.0, 0.0, 0.0, 1.0]
+      # autoware
       vad2base: [0.0, 1.0, 0.0, 0.0,
                 -1.0, 0.0, 0.0, 0.0,
                  0.0, 0.0, 1.0, 0.0,

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    node_params:
+      num_cameras: 6
     interface_params:
       # # awsim
       input_image_width: 1920

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/vad_tiny.param.yaml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/config/vad_tiny.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    node_params:
+      use_raw: [false, false, false, false, false, false] # per camera: if true, use raw image data, otherwise use compressed images
     model_params:
       plugins_path: "/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so"
       warm_up_num: 20

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -176,6 +176,7 @@ private:
     const std::vector<float> & prev_can_bus) const;
 
   std::tuple<float, float, float> aw2vad_xyz(float aw_x, float aw_y, float aw_z) const;
+  std::tuple<float, float, float> vad2aw_xyz(float vad_x, float vad_y, float vad_z) const;
   Eigen::Quaternionf aw2vad_quaternion(const Eigen::Quaternionf & q_aw) const;
 
   // Calculate current longitudinal velocity from can_bus data

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -154,6 +154,9 @@ private:
   Eigen::Matrix4f vad2base_;
   Eigen::Matrix4f base2vad_;
   std::unordered_map<int32_t, int32_t> autoware_to_vad_camera_mapping_;
+  
+  // Current longitudinal velocity for trajectory initial point
+  float current_longitudinal_velocity_mps_;
 
   // --- 内部処理関数 ---
   std::optional<Eigen::Matrix4f> lookup_base2cam(tf2_ros::Buffer & buffer, int32_t autoware_camera_id) const;
@@ -174,6 +177,12 @@ private:
 
   std::tuple<float, float, float> aw2vad_xyz(float aw_x, float aw_y, float aw_z) const;
   Eigen::Quaternionf aw2vad_quaternion(const Eigen::Quaternionf & q_aw) const;
+
+  // Calculate current longitudinal velocity from can_bus data
+  float calculate_current_longitudinal_velocity(
+    const std::vector<float> & can_bus,
+    const std::vector<float> & prev_can_bus,
+    double node_timestep) const;
 
   // Helper function for trajectory conversion
   geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw) const;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -186,7 +186,7 @@ private:
     double node_timestep) const;
 
   // Helper function for trajectory conversion
-  geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw) const;
+  geometry_msgs::msg::Quaternion create_quaternion_from_yaw(double yaw) const;
   
   // Helper function for creating trajectory points from predicted trajectory
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_trajectory_points(

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -177,6 +177,11 @@ private:
 
   // Helper function for trajectory conversion
   geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw) const;
+  
+  // Helper function for creating trajectory points from predicted trajectory
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_trajectory_points(
+    const std::vector<float> & predicted_trajectory,
+    double trajectory_timestep) const;
 };
 
 }  // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -109,18 +109,21 @@ public:
   VadOutputTopicData convert_output(
     const VadOutputData & vad_output_data, 
     const rclcpp::Time & stamp,
-    double trajectory_timestep) const;
+    double trajectory_timestep,
+    const Eigen::Matrix4f & base2map_transform) const;
 
   // Conversion methods for trajectories
   autoware_internal_planning_msgs::msg::CandidateTrajectories process_candidate_trajectories(
     const std::map<int32_t, std::vector<float>> & predicted_trajectories,
     const rclcpp::Time & stamp,
-    double trajectory_timestep) const;
+    double trajectory_timestep,
+    const Eigen::Matrix4f & base2map_transform) const;
   
   autoware_planning_msgs::msg::Trajectory process_trajectory(
     const std::vector<float> & predicted_trajectory,
     const rclcpp::Time & stamp,
-    double trajectory_timestep) const;
+    double trajectory_timestep,
+    const Eigen::Matrix4f & base2map_transform) const;
 
   Lidar2ImgData process_lidar2img(
     const tf2_msgs::msg::TFMessage::ConstSharedPtr & tf_static,
@@ -191,7 +194,8 @@ private:
   // Helper function for creating trajectory points from predicted trajectory
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_trajectory_points(
     const std::vector<float> & predicted_trajectory,
-    double trajectory_timestep) const;
+    double trajectory_timestep,
+    const Eigen::Matrix4f & base2map_transform) const;
 };
 
 }  // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -129,7 +129,7 @@ public:
   explicit VadInterface(const VadInterfaceConfig& config, 
                         std::shared_ptr<tf2_ros::Buffer> tf_buffer);
 
-  VadInputData convert_input(const VadInputTopicData & vad_input_topic_data, const std::vector<float> & prev_can_bus = {});
+  VadInputData convert_input(const VadInputTopicData & vad_input_topic_data);
   VadOutputTopicData convert_output(
     const VadOutputData & vad_output_data, 
     const rclcpp::Time & stamp,
@@ -184,6 +184,9 @@ private:
   
   // Current longitudinal velocity for trajectory initial point
   float current_longitudinal_velocity_mps_;
+  
+  // Previous can_bus data for velocity calculation and other processes
+  std::vector<float> prev_can_bus_;
 
   // --- 内部処理関数 ---
   std::optional<Eigen::Matrix4f> lookup_base2cam(tf2_ros::Buffer & buffer, int32_t autoware_camera_id) const;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -20,6 +20,8 @@
 #include <unordered_map>
 #include <optional>
 #include <tuple>
+#include <map>
+#include <cmath>
 
 #include "vad_interface_config.hpp"
 
@@ -31,6 +33,13 @@
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
 #include <tf2_eigen/tf2_eigen.hpp>
+#include "autoware_internal_planning_msgs/msg/candidate_trajectories.hpp"
+#include "autoware_internal_planning_msgs/msg/candidate_trajectory.hpp"
+#include "autoware_internal_planning_msgs/msg/generator_info.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "autoware_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_utils_uuid/uuid_helper.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
 
 #include "vad_model.hpp" 
 
@@ -73,6 +82,13 @@ struct VadInputTopicData
   }
 };
 
+struct VadOutputTopicData
+{
+  autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories;
+  autoware_planning_msgs::msg::Trajectory trajectory;
+  // autoware_perception_msgs::msg::DetectedObjects objects;
+};
+
 // 各process_*メソッドの戻り値となるデータ構造
 using CameraImagesData = std::vector<float>;
 using ShiftData = std::vector<float>;
@@ -90,6 +106,22 @@ public:
                         std::shared_ptr<tf2_ros::Buffer> tf_buffer);
 
   VadInputData convert_input(const VadInputTopicData & vad_input_topic_data, const std::vector<float> & prev_can_bus = {});
+  VadOutputTopicData convert_output(
+    const VadOutputData & vad_output_data, 
+    const rclcpp::Time & stamp,
+    double trajectory_timestep) const;
+
+  // Conversion methods for trajectories
+  autoware_internal_planning_msgs::msg::CandidateTrajectories process_candidate_trajectories(
+    const std::map<int32_t, std::vector<float>> & predicted_trajectories,
+    const rclcpp::Time & stamp,
+    double trajectory_timestep) const;
+  
+  autoware_planning_msgs::msg::Trajectory process_trajectory(
+    const std::vector<float> & predicted_trajectory,
+    const rclcpp::Time & stamp,
+    double trajectory_timestep) const;
+
   Lidar2ImgData process_lidar2img(
     const tf2_msgs::msg::TFMessage::ConstSharedPtr & tf_static,
     const std::vector<sensor_msgs::msg::CameraInfo::ConstSharedPtr> & camera_infos,
@@ -142,6 +174,9 @@ private:
 
   std::tuple<float, float, float> aw2vad_xyz(float aw_x, float aw_y, float aw_z) const;
   Eigen::Quaternionf aw2vad_quaternion(const Eigen::Quaternionf & q_aw) const;
+
+  // Helper function for trajectory conversion
+  geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw) const;
 };
 
 }  // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -68,17 +68,41 @@ struct VadInputTopicData
   // IMUデータ（/sensing/imu/tamagawa/imu_raw などから）
   sensor_msgs::msg::Imu::ConstSharedPtr imu_raw;
 
+private:
+  int32_t num_cameras_;
+
+public:
+  // コンストラクタ：カメラ数を指定してベクターを初期化
+  explicit VadInputTopicData(int32_t num_cameras) : num_cameras_(num_cameras) {
+    images.resize(num_cameras_);
+    camera_infos.resize(num_cameras_);
+  }
+
   // フレームが完成しているかをチェック
   bool is_complete() const {
-    if (images.size() != 6 || camera_infos.size() != 6) return false;
+    if (static_cast<int32_t>(images.size()) != num_cameras_ || 
+        static_cast<int32_t>(camera_infos.size()) != num_cameras_) {
+      return false;
+    }
     
-    for (int32_t i = 0; i < 6; ++i) {
+    for (int32_t i = 0; i < num_cameras_; ++i) {
       if (!images[i] || !camera_infos[i]) return false;
     }
     
     return tf_static != nullptr && 
            kinematic_state != nullptr && 
            imu_raw != nullptr;
+  }
+
+  // フレームをリセットする
+  void reset() {
+    images.clear();
+    images.resize(num_cameras_);
+    camera_infos.clear();
+    camera_infos.resize(num_cameras_);
+    kinematic_state.reset();
+    imu_raw.reset();
+    tf_static.reset();
   }
 };
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface_config.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface_config.hpp
@@ -23,6 +23,7 @@ public:
   float default_patch_angle;
   int32_t default_command;
   std::vector<float> default_shift;
+  std::vector<float> default_can_bus;
   std::array<float, 3> image_normalization_param_mean;
   std::array<float, 3> image_normalization_param_std;
   Eigen::Matrix4f vad2base;
@@ -38,6 +39,7 @@ public:
     double default_patch_angle_,
     int32_t default_command_,
     const std::vector<double>& default_shift_,
+    const std::vector<double>& default_can_bus_,
     const std::vector<double>& image_normalization_param_mean_,
     const std::vector<double>& image_normalization_param_std_,
     const std::vector<double>& vad2base_,
@@ -58,6 +60,9 @@ public:
     // default_shift: copy and convert
     default_shift.clear();
     for (auto v : default_shift_) default_shift.push_back(static_cast<float>(v));
+    // default_can_bus: copy and convert
+    default_can_bus.clear();
+    for (auto v : default_can_bus_) default_can_bus.push_back(static_cast<float>(v));
     // normalization mean/std: 3 elements
     for (int i = 0; i < 3; ++i) {
       image_normalization_param_mean[i] = static_cast<float>(image_normalization_param_mean_[i]);

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -231,16 +231,14 @@ public:
 
   // ロガーインスタンス
   std::shared_ptr<VadLogger> logger_;
-  std::unique_ptr<Logger> tensorrt_logger_;
 
 private:
   // メンバ関数
   std::unique_ptr<nvinfer1::IRuntime, std::function<void(nvinfer1::IRuntime*)>> create_runtime() {
-    // メンバ変数としてtensorrt_logger_を作成・保持
-    tensorrt_logger_ = std::make_unique<Logger>(logger_);
+    static std::unique_ptr<Logger> logger_instance = std::make_unique<Logger>(logger_);
     auto runtime_deleter = []([[maybe_unused]] nvinfer1::IRuntime *runtime) {};
     std::unique_ptr<nvinfer1::IRuntime, decltype(runtime_deleter)> runtime{
-        nvinfer1::createInferRuntime(*tensorrt_logger_), runtime_deleter};
+        nvinfer1::createInferRuntime(*logger_instance), runtime_deleter};
     return runtime;
   }
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -231,14 +231,17 @@ public:
 
   // ロガーインスタンス
   std::shared_ptr<VadLogger> logger_;
+  // TensorRTロガーインスタンス（VadModelの寿命と同じにする）
+  std::unique_ptr<Logger> tensorrt_logger_;
 
 private:
   // メンバ関数
   std::unique_ptr<nvinfer1::IRuntime, std::function<void(nvinfer1::IRuntime*)>> create_runtime() {
-    static std::unique_ptr<Logger> logger_instance = std::make_unique<Logger>(logger_);
+    // メンバ変数としてtensorrt_logger_を作成・保持
+    tensorrt_logger_ = std::make_unique<Logger>(logger_);
     auto runtime_deleter = []([[maybe_unused]] nvinfer1::IRuntime *runtime) {};
     std::unique_ptr<nvinfer1::IRuntime, decltype(runtime_deleter)> runtime{
-        nvinfer1::createInferRuntime(*logger_instance), runtime_deleter};
+        nvinfer1::createInferRuntime(*tensorrt_logger_), runtime_deleter};
     return runtime;
   }
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -231,7 +231,6 @@ public:
 
   // ロガーインスタンス
   std::shared_ptr<VadLogger> logger_;
-  // TensorRTロガーインスタンス（VadModelの寿命と同じにする）
   std::unique_ptr<Logger> tensorrt_logger_;
 
 private:

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -51,7 +51,7 @@
 namespace autoware::tensorrt_vad
 {
 
-class VadNode : public rclcpp::Node, public std::enable_shared_from_this<VadNode>
+class VadNode : public rclcpp::Node
 {
 public:
   explicit VadNode(const rclcpp::NodeOptions & options);

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -16,6 +16,8 @@
 #define AUTOWARE_TENSORRT_VAD_VAD_NODE_HPP_
 
 #include "autoware/tensorrt_vad/vad_model.hpp"
+#include "autoware/tensorrt_vad/vad_interface.hpp"
+#include "autoware/tensorrt_vad/vad_interface_config.hpp"
 #include "ros_vad_logger.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -30,12 +32,21 @@
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#include <tf2_msgs/msg/tf_message.hpp>
+#include <cv_bridge/cv_bridge.h>
 
 #include <cmath>
 #include <memory>
+#include <vector>
+#include <map>
+#include <mutex>
 
 // Forward declarations for future use
 // #include <cuda_runtime.h>
@@ -45,37 +56,81 @@
 namespace autoware::tensorrt_vad
 {
 
-class VadNode : public rclcpp::Node
+class VadNode : public rclcpp::Node, public std::enable_shared_from_this<VadNode>
 {
 public:
   explicit VadNode(const rclcpp::NodeOptions & options);
 
 private:
-  void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id);
-  void camera_info_callback(const sensor_msgs::msg::CameraInfo & msg, std::size_t camera_id);
+  // Config loading function
+  void loadVadConfig();
+  void loadNetConfigs();
+  void initializeVadModel();
 
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr> image_subs_{};
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_{};
+  // Publisher methods referencing main.cpp
+  void publishTrajectory(const std::vector<float> & planning);
+  void publishTrajectories(const std::map<int32_t, std::vector<float>> & trajectories_map);
 
+  // Helper function from main.cpp
+  geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw);
+
+  void image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg, std::size_t camera_id);
+  void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id);
+  void odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+  void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg);
+  void tf_static_callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
+
+  // Helper functions for data synchronization
+  void check_and_process_frame();
+  void reset_current_frame();
+  void frame_timeout_callback();
+
+  // Member variables in declaration order to match constructor initialization
+  VadInterfaceConfig vad_interface_config_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
+
+  // VAD interface config and previous can bus data (public like in main.cpp)
+  std::vector<float> prev_can_bus_;
+
+  // Subscribers for images (CompressedImage like in main.cpp)
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr> camera_image_subs_;
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;
+
+  // Subscribers for odometry and IMU data
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_static_sub_;
 
   // VAD model - 具体的なロガー型を指定
   std::unique_ptr<VadModel<RosVadLogger>> vad_model_ptr_{};
 
-  // VAD input topic
-  // std::unique_ptr<VadInputTopicData> vad_topic_data_ptr_{};
-
   // VAD interface
-  // std::unique_ptr<VadInterface> vad_interface_ptr_{};
+  std::unique_ptr<VadInterface> vad_interface_ptr_{};
 
-  // Publishers
-  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr trajectory_pub_{nullptr};
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr candidate_trajectories_pub_{nullptr};
-  // rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr detected_objects_pub_{nullptr};
+  // VAD config
+  VadConfig vad_config_;
+
+  // trajectory_timestep parameter like in main.cpp
+  double trajectory_timestep_;
+
+  // Publishers like in main.cpp
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr trajectory_publisher_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr candidate_trajectories_publisher_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_publisher_;
+
+  // Current frame data accumulation
+  VadInputTopicData current_frame_;
+  bool frame_started_;
+  std::mutex frame_mutex_;
+  
+  // Timeout timer for frame completion
+  rclcpp::TimerBase::SharedPtr frame_timeout_timer_;
+  static constexpr std::chrono::milliseconds FRAME_TIMEOUT{100}; // 100ms timeout
 
   // 推論を実行するメソッド
-  // std::tuple<std::optional<autoware_planning_msgs::msg::Trajectory>, std::optional<autoware_perception_msgs::msg::DetectedObjects> > execute_inference(const VadInputTopicData & vad_topic_data);
+  std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> execute_inference(const VadInputTopicData & vad_topic_data);
+  void publish(const VadInputTopicData & vad_topic_data);
 };
 }  // namespace autoware::tensorrt_vad
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -64,14 +64,10 @@ private:
   void initializeVadModel();
 
   // Publisher methods
-  void publishTrajectory(const std::vector<float> & planning);
+  void publishTrajectory(const autoware_planning_msgs::msg::Trajectory & trajectory);
   void publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories);
 
   // Conversion methods
-  autoware_internal_planning_msgs::msg::CandidateTrajectories convert_candidate_trajectories(const std::map<int32_t, std::vector<float>> & trajectories_map);
-
-  // Helper function
-  geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw);
 
   void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id);
   void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id);
@@ -128,7 +124,7 @@ private:
   static constexpr std::chrono::milliseconds FRAME_TIMEOUT{180}; // 180ms timeout
 
   // 推論を実行するメソッド
-  std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> execute_inference(const VadInputTopicData & vad_topic_data);
+  std::optional<VadOutputTopicData> execute_inference(const VadInputTopicData & vad_topic_data);
   void publish(const VadInputTopicData & vad_topic_data);
 };
 }  // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -59,13 +59,13 @@ public:
 
 private:
   // Config loading function
-  void loadVadConfig();
-  void loadNetConfigs();
-  void initializeVadModel();
+  void load_vad_config();
+  void load_net_configs();
+  void initialize_vad_model();
 
   // Publisher methods
-  void publishTrajectory(const autoware_planning_msgs::msg::Trajectory & trajectory);
-  void publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories);
+  void publish_trajectory(const autoware_planning_msgs::msg::Trajectory & trajectory);
+  void publish_trajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories);
 
   // Conversion methods
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -126,7 +126,7 @@ private:
   
   // Timeout timer for frame completion
   rclcpp::TimerBase::SharedPtr frame_timeout_timer_;
-  static constexpr std::chrono::milliseconds FRAME_TIMEOUT{100}; // 100ms timeout
+  static constexpr std::chrono::milliseconds FRAME_TIMEOUT{180}; // 180ms timeout
 
   // 推論を実行するメソッド
   std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> execute_inference(const VadInputTopicData & vad_topic_data);

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -85,6 +85,9 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
+  // Number of cameras (configured via parameter)
+  int32_t num_cameras_;
+
   // VAD interface config and previous can bus data
   std::vector<float> prev_can_bus_;
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -88,9 +88,6 @@ private:
   // Number of cameras (configured via parameter)
   int32_t num_cameras_;
 
-  // VAD interface config and previous can bus data
-  std::vector<float> prev_can_bus_;
-
   // Subscribers for images (using image_transport)
   std::vector<image_transport::Subscriber> camera_image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -64,7 +64,10 @@ private:
 
   // Publisher methods
   void publishTrajectory(const std::vector<float> & planning);
-  void publishTrajectories(const std::map<int32_t, std::vector<float>> & trajectories_map);
+  void publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories);
+
+  // Conversion methods
+  autoware_internal_planning_msgs::msg::CandidateTrajectories convert_candidate_trajectories(const std::map<int32_t, std::vector<float>> & trajectories_map);
 
   // Helper function
   geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw);

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -67,11 +67,11 @@ private:
   void loadNetConfigs();
   void initializeVadModel();
 
-  // Publisher methods referencing main.cpp
+  // Publisher methods
   void publishTrajectory(const std::vector<float> & planning);
   void publishTrajectories(const std::map<int32_t, std::vector<float>> & trajectories_map);
 
-  // Helper function from main.cpp
+  // Helper function
   geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw);
 
   void image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg, std::size_t camera_id);
@@ -90,10 +90,10 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
-  // VAD interface config and previous can bus data (public like in main.cpp)
+  // VAD interface config and previous can bus data
   std::vector<float> prev_can_bus_;
 
-  // Subscribers for images (CompressedImage like in main.cpp)
+  // Subscribers for images (CompressedImage)
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr> camera_image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;
 
@@ -111,10 +111,10 @@ private:
   // VAD config
   VadConfig vad_config_;
 
-  // trajectory_timestep parameter like in main.cpp
+  // trajectory_timestep parameter
   double trajectory_timestep_;
 
-  // Publishers like in main.cpp
+  // Publishers
   rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr trajectory_publisher_;
   rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr candidate_trajectories_publisher_;
   rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_publisher_;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -69,8 +69,7 @@ private:
   void publish_trajectory(const autoware_planning_msgs::msg::Trajectory & trajectory);
   void publish_trajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories);
 
-  // Conversion methods
-
+  // Callback methods
   void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id);
   void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id);
   void odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
@@ -82,8 +81,7 @@ private:
   void reset_current_frame();
   void frame_timeout_callback();
 
-  // Member variables in declaration order to match constructor initialization
-  VadInterfaceConfig vad_interface_config_;
+  // tf Members
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
@@ -99,14 +97,14 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_static_sub_;
 
-  // VAD model - 具体的なロガー型を指定
+  // VAD model
   std::unique_ptr<VadModel<RosVadLogger>> vad_model_ptr_{};
+  VadConfig vad_config_;
 
   // VAD interface
   std::unique_ptr<VadInterface> vad_interface_ptr_{};
+  VadInterfaceConfig vad_interface_config_;
 
-  // VAD config
-  VadConfig vad_config_;
 
   // trajectory_timestep parameter
   double trajectory_timestep_;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -62,6 +62,8 @@ private:
   void load_vad_config();
   void load_net_configs();
   void initialize_vad_model();
+  void create_camera_image_subscribers(const rclcpp::QoS& sensor_qos);
+  void create_camera_info_subscribers(const rclcpp::QoS& camera_info_qos);
 
   // Publisher methods
   void publish_trajectory(const autoware_planning_msgs::msg::Trajectory & trajectory);

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -20,6 +20,7 @@
 #include "autoware/tensorrt_vad/vad_interface_config.hpp"
 #include "ros_vad_logger.hpp"
 
+#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
@@ -72,7 +73,7 @@ private:
   // Helper function
   geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw);
 
-  void image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg, std::size_t camera_id);
+  void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id);
   void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id);
   void odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
   void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg);
@@ -91,8 +92,8 @@ private:
   // VAD interface config and previous can bus data
   std::vector<float> prev_can_bus_;
 
-  // Subscribers for images (CompressedImage)
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr> camera_image_subs_;
+  // Subscribers for images (using image_transport)
+  std::vector<image_transport::Subscriber> camera_image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;
 
   // Subscribers for odometry and IMU data

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -48,11 +48,6 @@
 #include <map>
 #include <mutex>
 
-// Forward declarations for future use
-// #include <cuda_runtime.h>
-// #include <NvInfer.h>
-// #include <stb/stb_image.h>
-
 namespace autoware::tensorrt_vad
 {
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="log_level" default="info"/>
+  <arg name="rviz" default="false" description="launch rviz"/>
+  <arg name="rviz_respawn" default="true" description="respawn rviz"/>
 
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info"/>
   <arg name="camera_info1" default="/sensing/camera/camera1/camera_info"/>
@@ -49,4 +51,19 @@
     <remap from="~/input/imu_raw" to="$(var imu_raw)"/>
     <remap from="~/input/tf_static" to="$(var tf_static)"/>
   </node>
+
+  <!-- Rviz for individual node testing-->
+  <arg name="rviz_config_name" default="perception.rviz" description="rviz config name"/>
+  <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/$(var rviz_config_name)" description="rviz config path"/>
+  <group>
+    <node
+      pkg="rviz2"
+      exec="rviz2"
+      name="rviz2"
+      output="screen"
+      if="$(var rviz)"
+      args="-d $(var rviz_config) -s $(find-pkg-share autoware_launch)/rviz/image/autoware.png"
+      respawn="$(var rviz_respawn)"
+    />
+  </group>
 </launch>

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
@@ -11,16 +11,15 @@
   <arg name="camera_info4" default="/sensing/camera/camera4/camera_info"/>
   <arg name="camera_info5" default="/sensing/camera/camera5/camera_info"/>
 
-  <arg name="image0" default="/sensing/camera/camera0/image_rect_color/compressed"/>
-  <arg name="image1" default="/sensing/camera/camera1/image_rect_color/compressed"/>
-  <arg name="image2" default="/sensing/camera/camera2/image_rect_color/compressed"/>
-  <arg name="image3" default="/sensing/camera/camera3/image_rect_color/compressed"/>
-  <arg name="image4" default="/sensing/camera/camera4/image_rect_color/compressed"/>
-  <arg name="image5" default="/sensing/camera/camera5/image_rect_color/compressed"/>
+  <arg name="image0" default="/sensing/camera/camera0/image_rect_color"/>
+  <arg name="image1" default="/sensing/camera/camera1/image_rect_color"/>
+  <arg name="image2" default="/sensing/camera/camera2/image_rect_color"/>
+  <arg name="image3" default="/sensing/camera/camera3/image_rect_color"/>
+  <arg name="image4" default="/sensing/camera/camera4/image_rect_color"/>
+  <arg name="image5" default="/sensing/camera/camera5/image_rect_color"/>
 
   <arg name="kinematic_state" default="/localization/kinematic_state"/>
   <arg name="imu_raw" default="/sensing/imu/tamagawa/imu_raw"/>
-  <arg name="tf_static" default="/tf_static"/>
 
   <arg name="output/objects" default="perception/object_recognition/detection/vad/objects"/>
   <arg name="output/trajectory" default="planning/vad/trajectory"/>
@@ -49,7 +48,6 @@
     
     <remap from="~/input/kinematic_state" to="$(var kinematic_state)"/>
     <remap from="~/input/imu_raw" to="$(var imu_raw)"/>
-    <remap from="~/input/tf_static" to="$(var tf_static)"/>
   </node>
 
   <!-- Rviz for individual node testing-->

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
@@ -9,18 +9,28 @@
   <arg name="camera_info4" default="/sensing/camera/camera4/camera_info"/>
   <arg name="camera_info5" default="/sensing/camera/camera5/camera_info"/>
 
-  <arg name="image0" default="/sensing/camera/camera0/image_rect_color"/>
-  <arg name="image1" default="/sensing/camera/camera1/image_rect_color"/>
-  <arg name="image2" default="/sensing/camera/camera2/image_rect_color"/>
-  <arg name="image3" default="/sensing/camera/camera3/image_rect_color"/>
-  <arg name="image4" default="/sensing/camera/camera4/image_rect_color"/>
-  <arg name="image5" default="/sensing/camera/camera5/image_rect_color"/>
-  <arg name="output/objects" default="detection/objects"/>
-  <arg name="output/trajectory" default="planning/trajectory"/>
+  <arg name="image0" default="/sensing/camera/camera0/image_rect_color/compressed"/>
+  <arg name="image1" default="/sensing/camera/camera1/image_rect_color/compressed"/>
+  <arg name="image2" default="/sensing/camera/camera2/image_rect_color/compressed"/>
+  <arg name="image3" default="/sensing/camera/camera3/image_rect_color/compressed"/>
+  <arg name="image4" default="/sensing/camera/camera4/image_rect_color/compressed"/>
+  <arg name="image5" default="/sensing/camera/camera5/image_rect_color/compressed"/>
+
+  <arg name="kinematic_state" default="/localization/kinematic_state"/>
+  <arg name="imu_raw" default="/sensing/imu/tamagawa/imu_raw"/>
+  <arg name="tf_static" default="/tf_static"/>
+
+  <arg name="output/objects" default="perception/object_recognition/detection/vad/objects"/>
+  <arg name="output/trajectory" default="planning/vad/trajectory"/>
+  <arg name="output/trajectories" default="planning/vad/trajectories"/>
 
   <node pkg="autoware_tensorrt_vad" exec="vad_node" name="vad" output="screen" args="--ros-args --log-level $(var log_level)">
+    <param from="$(find-pkg-share autoware_tensorrt_vad)/config/vad_tiny.param.yaml"/>
+    <param from="$(find-pkg-share autoware_tensorrt_vad)/config/ml_package_vad_tiny.param.yaml"/>
+    
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <remap from="~/output/trajectory" to="$(var output/trajectory)"/>
+    <remap from="~/output/trajectories" to="$(var output/trajectories)"/>
 
     <remap from="~/input/camera_info0" to="$(var camera_info0)"/>
     <remap from="~/input/camera_info1" to="$(var camera_info1)"/>
@@ -34,5 +44,9 @@
     <remap from="~/input/image3" to="$(var image3)"/>
     <remap from="~/input/image4" to="$(var image4)"/>
     <remap from="~/input/image5" to="$(var image5)"/>
+    
+    <remap from="~/input/kinematic_state" to="$(var kinematic_state)"/>
+    <remap from="~/input/imu_raw" to="$(var imu_raw)"/>
+    <remap from="~/input/tf_static" to="$(var tf_static)"/>
   </node>
 </launch>

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -417,7 +417,7 @@ Eigen::Quaternionf VadInterface::aw2vad_quaternion(const Eigen::Quaternionf & q_
   return q_v2a * q_aw * q_v2a_inv;
 }
 
-geometry_msgs::msg::Quaternion VadInterface::createQuaternionFromYaw(double yaw) const
+geometry_msgs::msg::Quaternion VadInterface::create_quaternion_from_yaw(double yaw) const
 {
   geometry_msgs::msg::Quaternion q{};
   q.x = 0.0;
@@ -438,7 +438,7 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
   initial_point.pose.position.x = 0.0;
   initial_point.pose.position.y = 0.0;
   initial_point.pose.position.z = 0.0;
-  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+  initial_point.pose.orientation = create_quaternion_from_yaw(0.0);
   initial_point.longitudinal_velocity_mps = current_longitudinal_velocity_mps_;
   initial_point.lateral_velocity_mps = 0.0;
   initial_point.acceleration_mps2 = 0.0;
@@ -462,9 +462,9 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
       float vad_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
       auto [aw_dx, aw_dy, aw_dz] = vad2aw_xyz(vad_dx, vad_dy, 0.0f);
       float yaw = std::atan2(aw_dy, aw_dx);
-      point.pose.orientation = createQuaternionFromYaw(yaw);
+      point.pose.orientation = create_quaternion_from_yaw(yaw);
     } else {
-      point.pose.orientation = createQuaternionFromYaw(0.0);
+      point.pose.orientation = create_quaternion_from_yaw(0.0);
     }
 
     // 速度を計算（前の点との距離を時間間隔で割る）

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -23,13 +23,14 @@ VadInterface::VadInterface(const VadInterfaceConfig& config, std::shared_ptr<tf2
     image_normalization_param_std_(config.image_normalization_param_std),
     vad2base_(config.vad2base),
     base2vad_(config.base2vad),
-    current_longitudinal_velocity_mps_(0.0f)
+    current_longitudinal_velocity_mps_(0.0f),
+    prev_can_bus_(config.default_can_bus)
 {
   // AutowareカメラインデックスからVADカメラインデックスへのマッピング
   autoware_to_vad_camera_mapping_ = config.autoware_to_vad_camera_mapping;
 }
 
-VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_topic_data, const std::vector<float> & prev_can_bus)
+VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_topic_data)
 {
   VadInputData vad_input_data;
 
@@ -47,20 +48,23 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
   vad_input_data.can_bus_ = process_can_bus(
     vad_input_topic_data.kinematic_state,
     vad_input_topic_data.imu_raw,
-    prev_can_bus
+    prev_can_bus_
   );
-  vad_input_data.shift_ = process_shift(vad_input_data.can_bus_, prev_can_bus);
+  vad_input_data.shift_ = process_shift(vad_input_data.can_bus_, prev_can_bus_);
   
   // Calculate current longitudinal velocity (node_timestep = 100ms = 0.1s)
   constexpr double node_timestep = 0.1;
   current_longitudinal_velocity_mps_ = calculate_current_longitudinal_velocity(
-    vad_input_data.can_bus_, prev_can_bus, node_timestep);
+    vad_input_data.can_bus_, prev_can_bus_, node_timestep);
   
   // Process image data
   vad_input_data.camera_images_ = process_image(vad_input_topic_data.images);
   
   // Set default command
   vad_input_data.command_ = default_command_;
+  
+  // Update prev_can_bus_ for next iteration
+  prev_can_bus_ = vad_input_data.can_bus_;
   
   return vad_input_data;
 }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -22,7 +22,8 @@ VadInterface::VadInterface(const VadInterfaceConfig& config, std::shared_ptr<tf2
     image_normalization_param_mean_(config.image_normalization_param_mean),
     image_normalization_param_std_(config.image_normalization_param_std),
     vad2base_(config.vad2base),
-    base2vad_(config.base2vad)
+    base2vad_(config.base2vad),
+    current_longitudinal_velocity_mps_(0.0f)
 {
   // AutowareカメラインデックスからVADカメラインデックスへのマッピング
   autoware_to_vad_camera_mapping_ = config.autoware_to_vad_camera_mapping;
@@ -49,6 +50,11 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
     prev_can_bus
   );
   vad_input_data.shift_ = process_shift(vad_input_data.can_bus_, prev_can_bus);
+  
+  // Calculate current longitudinal velocity (node_timestep = 100ms = 0.1s)
+  constexpr double node_timestep = 0.1;
+  current_longitudinal_velocity_mps_ = calculate_current_longitudinal_velocity(
+    vad_input_data.can_bus_, prev_can_bus, node_timestep);
   
   // Process image data
   vad_input_data.camera_images_ = process_image(vad_input_topic_data.images);
@@ -425,7 +431,7 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
   initial_point.pose.position.y = 0.0;
   initial_point.pose.position.z = 0.0;
   initial_point.pose.orientation = createQuaternionFromYaw(0.0);
-  initial_point.longitudinal_velocity_mps = 0.0;
+  initial_point.longitudinal_velocity_mps = current_longitudinal_velocity_mps_;
   initial_point.lateral_velocity_mps = 0.0;
   initial_point.acceleration_mps2 = 0.0;
   initial_point.heading_rate_rps = 0.0;
@@ -525,6 +531,28 @@ autoware_planning_msgs::msg::Trajectory VadInterface::process_trajectory(
   trajectory_msg.points = create_trajectory_points(predicted_trajectory, trajectory_timestep);
 
   return trajectory_msg;
+}
+
+float VadInterface::calculate_current_longitudinal_velocity(
+  const std::vector<float> & can_bus,
+  const std::vector<float> & prev_can_bus,
+  double node_timestep) const
+{
+  if (prev_can_bus.empty() || can_bus.size() < 3 || prev_can_bus.size() < 3) {
+    return 0.0f; // 前フレームのデータがない場合は0を返す
+  }
+
+  // can_busの位置データから速度を計算 (位置: indices 0, 1)
+  float delta_x = can_bus[0] - prev_can_bus[0];  // x方向の変位
+  float delta_y = can_bus[1] - prev_can_bus[1];  // y方向の変位
+
+  // 3次元での移動距離を計算
+  float distance = std::sqrt(delta_x * delta_x + delta_y * delta_y);
+
+  // 速度 = 距離 / 時間
+  float velocity = distance / static_cast<float>(node_timestep);
+  
+  return velocity;
 }
 
 } // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -413,6 +413,61 @@ geometry_msgs::msg::Quaternion VadInterface::createQuaternionFromYaw(double yaw)
   return q;
 }
 
+std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_trajectory_points(
+  const std::vector<float> & predicted_trajectory,
+  double trajectory_timestep) const
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points;
+  
+  // 0秒目の点 (0,0) を追加
+  autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+  initial_point.pose.position.x = 0.0;
+  initial_point.pose.position.y = 0.0;
+  initial_point.pose.position.z = 0.0;
+  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+  initial_point.longitudinal_velocity_mps = 0.0;
+  initial_point.lateral_velocity_mps = 0.0;
+  initial_point.acceleration_mps2 = 0.0;
+  initial_point.heading_rate_rps = 0.0;
+  initial_point.time_from_start.sec = 0;
+  initial_point.time_from_start.nanosec = 0;
+  points.push_back(initial_point);
+
+  for (size_t i = 0; i < predicted_trajectory.size(); i += 2) {
+    autoware_planning_msgs::msg::TrajectoryPoint point;
+
+    point.pose.position.x = predicted_trajectory[i + 1];
+    point.pose.position.y = -predicted_trajectory[i];
+    point.pose.position.z = 0.0;
+
+    if (i + 2 < predicted_trajectory.size()) {
+      float ns_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
+      float ns_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
+      float aw_dx = ns_dy;  // Autowareの座標系に変換
+      float aw_dy = -ns_dx; // Autowareの座標系に変換
+      float yaw = std::atan2(aw_dy, aw_dx);
+      point.pose.orientation = createQuaternionFromYaw(yaw);
+    } else {
+      point.pose.orientation = createQuaternionFromYaw(0.0);
+    }
+
+    point.longitudinal_velocity_mps = 0.0;
+    point.lateral_velocity_mps = 0.0;
+    point.acceleration_mps2 = 0.0;
+    point.heading_rate_rps = 0.0;
+
+    // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+    size_t point_index = i / 2;
+    double time_sec = (point_index + 1) * trajectory_timestep;
+    point.time_from_start.sec = static_cast<int32_t>(time_sec);
+    point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+    points.push_back(point);
+  }
+
+  return points;
+}
+
 autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::process_candidate_trajectories(
   const std::map<int32_t, std::vector<float>> & predicted_trajectories,
   const rclcpp::Time & stamp,
@@ -432,49 +487,7 @@ autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::proces
     // generator_idを設定（ユニークなUUID）
     candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
 
-    // 0秒目の点 (0,0) を追加
-    autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-    initial_point.pose.position.x = 0.0;
-    initial_point.pose.position.y = 0.0;
-    initial_point.pose.position.z = 0.0;
-    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
-    initial_point.longitudinal_velocity_mps = 0.0;
-    initial_point.lateral_velocity_mps = 0.0;
-    initial_point.acceleration_mps2 = 0.0;
-    initial_point.heading_rate_rps = 0.0;
-    initial_point.time_from_start.sec = 0;
-    initial_point.time_from_start.nanosec = 0;
-    candidate_trajectory.points.push_back(initial_point);
-
-    for (size_t i = 0; i < trajectory.size(); i += 2) {
-      autoware_planning_msgs::msg::TrajectoryPoint point;
-
-      point.pose.position.x = trajectory[i + 1];
-      point.pose.position.y = -trajectory[i];
-      point.pose.position.z = 0.0;
-
-      if (i + 2 < trajectory.size()) {
-        float ns_dx = trajectory[i + 2] - trajectory[i];
-        float ns_dy = trajectory[i + 3] - trajectory[i + 1];
-        float aw_dx = ns_dy;  // Autowareの座標系に変換
-        float aw_dy = -ns_dx; // Autowareの座標系に変換
-        float yaw = std::atan2(aw_dy, aw_dx);
-        point.pose.orientation = createQuaternionFromYaw(yaw);
-      }
-
-      point.longitudinal_velocity_mps = 0.0;
-      point.lateral_velocity_mps = 0.0;
-      point.acceleration_mps2 = 0.0;
-      point.heading_rate_rps = 0.0;
-
-      // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
-      size_t point_index = i / 2;
-      double time_sec = (point_index + 1) * trajectory_timestep;
-      point.time_from_start.sec = static_cast<int32_t>(time_sec);
-      point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
-
-      candidate_trajectory.points.push_back(point);
-    }
+    candidate_trajectory.points = create_trajectory_points(trajectory, trajectory_timestep);
 
     candidate_trajectories_msg.candidate_trajectories.push_back(candidate_trajectory);
 
@@ -499,49 +512,7 @@ autoware_planning_msgs::msg::Trajectory VadInterface::process_trajectory(
   trajectory_msg.header.stamp = stamp;
   trajectory_msg.header.frame_id = "base_link";
 
-  // 0秒目の点 (0,0) を追加
-  autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-  initial_point.pose.position.x = 0.0;
-  initial_point.pose.position.y = 0.0;
-  initial_point.pose.position.z = 0.0;
-  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
-  initial_point.longitudinal_velocity_mps = 0.0;
-  initial_point.lateral_velocity_mps = 0.0;
-  initial_point.acceleration_mps2 = 0.0;
-  initial_point.heading_rate_rps = 0.0;
-  initial_point.time_from_start.sec = 0;
-  initial_point.time_from_start.nanosec = 0;
-  trajectory_msg.points.push_back(initial_point);
-
-  for (size_t i = 0; i < predicted_trajectory.size(); i += 2) {
-    autoware_planning_msgs::msg::TrajectoryPoint point;
-
-    point.pose.position.x = predicted_trajectory[i + 1];
-    point.pose.position.y = -predicted_trajectory[i];
-    point.pose.position.z = 0.0;
-
-    if (i + 2 < predicted_trajectory.size()) {
-      float ns_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
-      float ns_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
-      float aw_dx = ns_dy;  // Autowareの座標系に変換
-      float aw_dy = -ns_dx; // Autowareの座標系に変換
-      float yaw = std::atan2(aw_dy, aw_dx);
-      point.pose.orientation = createQuaternionFromYaw(yaw);
-    }
-
-    point.longitudinal_velocity_mps = 0.0;
-    point.lateral_velocity_mps = 0.0;
-    point.acceleration_mps2 = 0.0;
-    point.heading_rate_rps = 0.0;
-
-    // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
-    size_t point_index = i / 2;
-    double time_sec = (point_index + 1) * trajectory_timestep;
-    point.time_from_start.sec = static_cast<int32_t>(time_sec);
-    point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
-
-    trajectory_msg.points.push_back(point);
-  }
+  trajectory_msg.points = create_trajectory_points(predicted_trajectory, trajectory_timestep);
 
   return trajectory_msg;
 }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -59,6 +59,24 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
   return vad_input_data;
 }
 
+VadOutputTopicData VadInterface::convert_output(
+  const VadOutputData & vad_output_data,
+  const rclcpp::Time & stamp,
+  double trajectory_timestep) const
+{
+  VadOutputTopicData output_topic_data;
+
+  // Convert candidate trajectories
+  output_topic_data.candidate_trajectories = process_candidate_trajectories(
+    vad_output_data.predicted_trajectories_, stamp, trajectory_timestep);
+  
+  // Convert trajectory
+  output_topic_data.trajectory = process_trajectory(
+    vad_output_data.predicted_trajectory_, stamp, trajectory_timestep);
+
+  return output_topic_data;
+}
+
 std::optional<Eigen::Matrix4f> VadInterface::lookup_base2cam(tf2_ros::Buffer & buffer, int32_t autoware_camera_id) const
 {
   std::string target_frame = "base_link";
@@ -385,4 +403,147 @@ Eigen::Quaternionf VadInterface::aw2vad_quaternion(const Eigen::Quaternionf & q_
   return q_v2a * q_aw * q_v2a_inv;
 }
 
-}  // namespace autoware::tensorrt_vad
+geometry_msgs::msg::Quaternion VadInterface::createQuaternionFromYaw(double yaw) const
+{
+  geometry_msgs::msg::Quaternion q{};
+  q.x = 0.0;
+  q.y = 0.0;
+  q.z = std::sin(yaw * 0.5);
+  q.w = std::cos(yaw * 0.5);
+  return q;
+}
+
+autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::process_candidate_trajectories(
+  const std::map<int32_t, std::vector<float>> & predicted_trajectories,
+  const rclcpp::Time & stamp,
+  double trajectory_timestep) const
+{
+  // CandidateTrajectories メッセージを作成
+  autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories_msg;
+
+  // 各コマンドの軌道をCandidateTrajectoryとして追加
+  for (const auto& [command_idx, trajectory] : predicted_trajectories) {
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    
+    // ヘッダーを設定
+    candidate_trajectory.header.stamp = stamp;
+    candidate_trajectory.header.frame_id = "base_link";
+    
+    // generator_idを設定（ユニークなUUID）
+    candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
+
+    // 0秒目の点 (0,0) を追加
+    autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+    initial_point.pose.position.x = 0.0;
+    initial_point.pose.position.y = 0.0;
+    initial_point.pose.position.z = 0.0;
+    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+    initial_point.longitudinal_velocity_mps = 0.0;
+    initial_point.lateral_velocity_mps = 0.0;
+    initial_point.acceleration_mps2 = 0.0;
+    initial_point.heading_rate_rps = 0.0;
+    initial_point.time_from_start.sec = 0;
+    initial_point.time_from_start.nanosec = 0;
+    candidate_trajectory.points.push_back(initial_point);
+
+    for (size_t i = 0; i < trajectory.size(); i += 2) {
+      autoware_planning_msgs::msg::TrajectoryPoint point;
+
+      point.pose.position.x = trajectory[i + 1];
+      point.pose.position.y = -trajectory[i];
+      point.pose.position.z = 0.0;
+
+      if (i + 2 < trajectory.size()) {
+        float ns_dx = trajectory[i + 2] - trajectory[i];
+        float ns_dy = trajectory[i + 3] - trajectory[i + 1];
+        float aw_dx = ns_dy;  // Autowareの座標系に変換
+        float aw_dy = -ns_dx; // Autowareの座標系に変換
+        float yaw = std::atan2(aw_dy, aw_dx);
+        point.pose.orientation = createQuaternionFromYaw(yaw);
+      }
+
+      point.longitudinal_velocity_mps = 0.0;
+      point.lateral_velocity_mps = 0.0;
+      point.acceleration_mps2 = 0.0;
+      point.heading_rate_rps = 0.0;
+
+      // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+      size_t point_index = i / 2;
+      double time_sec = (point_index + 1) * trajectory_timestep;
+      point.time_from_start.sec = static_cast<int32_t>(time_sec);
+      point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+      candidate_trajectory.points.push_back(point);
+    }
+
+    candidate_trajectories_msg.candidate_trajectories.push_back(candidate_trajectory);
+
+    // 各コマンドのGeneratorInfoを追加
+    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+    generator_info.generator_id = autoware_utils_uuid::generate_uuid();
+    generator_info.generator_name.data = "autoware_tensorrt_vad_cmd_" + std::to_string(command_idx);
+    candidate_trajectories_msg.generator_info.push_back(generator_info);
+  }
+
+  return candidate_trajectories_msg;
+}
+
+autoware_planning_msgs::msg::Trajectory VadInterface::process_trajectory(
+  const std::vector<float> & predicted_trajectory,
+  const rclcpp::Time & stamp,
+  double trajectory_timestep) const
+{
+  autoware_planning_msgs::msg::Trajectory trajectory_msg;
+
+  // ヘッダーを設定
+  trajectory_msg.header.stamp = stamp;
+  trajectory_msg.header.frame_id = "base_link";
+
+  // 0秒目の点 (0,0) を追加
+  autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+  initial_point.pose.position.x = 0.0;
+  initial_point.pose.position.y = 0.0;
+  initial_point.pose.position.z = 0.0;
+  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+  initial_point.longitudinal_velocity_mps = 0.0;
+  initial_point.lateral_velocity_mps = 0.0;
+  initial_point.acceleration_mps2 = 0.0;
+  initial_point.heading_rate_rps = 0.0;
+  initial_point.time_from_start.sec = 0;
+  initial_point.time_from_start.nanosec = 0;
+  trajectory_msg.points.push_back(initial_point);
+
+  for (size_t i = 0; i < predicted_trajectory.size(); i += 2) {
+    autoware_planning_msgs::msg::TrajectoryPoint point;
+
+    point.pose.position.x = predicted_trajectory[i + 1];
+    point.pose.position.y = -predicted_trajectory[i];
+    point.pose.position.z = 0.0;
+
+    if (i + 2 < predicted_trajectory.size()) {
+      float ns_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
+      float ns_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
+      float aw_dx = ns_dy;  // Autowareの座標系に変換
+      float aw_dy = -ns_dx; // Autowareの座標系に変換
+      float yaw = std::atan2(aw_dy, aw_dx);
+      point.pose.orientation = createQuaternionFromYaw(yaw);
+    }
+
+    point.longitudinal_velocity_mps = 0.0;
+    point.lateral_velocity_mps = 0.0;
+    point.acceleration_mps2 = 0.0;
+    point.heading_rate_rps = 0.0;
+
+    // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+    size_t point_index = i / 2;
+    double time_sec = (point_index + 1) * trajectory_timestep;
+    point.time_from_start.sec = static_cast<int32_t>(time_sec);
+    point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+    trajectory_msg.points.push_back(point);
+  }
+
+  return trajectory_msg;
+}
+
+} // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -68,17 +68,18 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
 VadOutputTopicData VadInterface::convert_output(
   const VadOutputData & vad_output_data,
   const rclcpp::Time & stamp,
-  double trajectory_timestep) const
+  double trajectory_timestep,
+  const Eigen::Matrix4f & base2map_transform) const
 {
   VadOutputTopicData output_topic_data;
 
   // Convert candidate trajectories
   output_topic_data.candidate_trajectories = process_candidate_trajectories(
-    vad_output_data.predicted_trajectories_, stamp, trajectory_timestep);
+    vad_output_data.predicted_trajectories_, stamp, trajectory_timestep, base2map_transform);
   
   // Convert trajectory
   output_topic_data.trajectory = process_trajectory(
-    vad_output_data.predicted_trajectory_, stamp, trajectory_timestep);
+    vad_output_data.predicted_trajectory_, stamp, trajectory_timestep, base2map_transform);
 
   return output_topic_data;
 }
@@ -429,17 +430,27 @@ geometry_msgs::msg::Quaternion VadInterface::create_quaternion_from_yaw(double y
 
 std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_trajectory_points(
   const std::vector<float> & predicted_trajectory,
-  double trajectory_timestep) const
+  double trajectory_timestep,
+  const Eigen::Matrix4f & base2map_transform) const
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points;
   
+  // base座標系の方向ベクトルをmap座標系に変換する関数内関数
+  auto transform_direction_to_map = [&base2map_transform](float base_dx, float base_dy) -> float {
+    Eigen::Vector3f base_direction(base_dx, base_dy, 0.0f);
+    Eigen::Vector3f map_direction = base2map_transform.block<3, 3>(0, 0) * base_direction;
+    return std::atan2(map_direction.y(), map_direction.x());
+  };
+  
   // 0秒目の点 (0,0) を追加
   autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-  initial_point.pose.position.x = 0.0;
-  initial_point.pose.position.y = 0.0;
-  initial_point.pose.position.z = 0.0;
-  initial_point.pose.orientation = create_quaternion_from_yaw(0.0);
-  initial_point.longitudinal_velocity_mps = current_longitudinal_velocity_mps_;
+  Eigen::Vector4f init_ego_position = base2map_transform * Eigen::Vector4f(0.0, 0.0, 0.0, 1.0);
+  initial_point.pose.position.x = init_ego_position[0];
+  initial_point.pose.position.y = init_ego_position[1];
+  initial_point.pose.position.z = init_ego_position[2];
+  // 初期方向もmap座標系に変換（base座標系でx方向を向いている場合）
+  initial_point.pose.orientation = create_quaternion_from_yaw(transform_direction_to_map(1.0f, 0.0f));
+  initial_point.longitudinal_velocity_mps = 2.5;
   initial_point.lateral_velocity_mps = 0.0;
   initial_point.acceleration_mps2 = 0.0;
   initial_point.heading_rate_rps = 0.0;
@@ -447,24 +458,33 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
   initial_point.time_from_start.nanosec = 0;
   points.push_back(initial_point);
 
-  double prev_x = 0.0;
-  double prev_y = 0.0;
+  double prev_x = init_ego_position[0];
+  double prev_y = init_ego_position[1];
+  auto prev_orientation = initial_point.pose.orientation;
 
   for (size_t i = 0; i < predicted_trajectory.size(); i += 2) {
     autoware_planning_msgs::msg::TrajectoryPoint point;
 
-    point.pose.position.x = predicted_trajectory[i + 1];
-    point.pose.position.y = -predicted_trajectory[i];
-    point.pose.position.z = 0.0;
+    float vad_x = predicted_trajectory[i];
+    float vad_y = predicted_trajectory[i + 1];
+
+    auto [aw_x, aw_y, aw_z] = vad2aw_xyz(vad_x, vad_y, 0.0f);
+    Eigen::Vector4f base_link_position(aw_x, aw_y, 0.0, 1.0);
+    Eigen::Vector4f map_position = base2map_transform * base_link_position;
+
+    point.pose.position.x = map_position[0];
+    point.pose.position.y = map_position[1];
+    point.pose.position.z = map_position[2];
 
     if (i + 2 < predicted_trajectory.size()) {
       float vad_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
       float vad_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
       auto [aw_dx, aw_dy, aw_dz] = vad2aw_xyz(vad_dx, vad_dy, 0.0f);
-      float yaw = std::atan2(aw_dy, aw_dx);
+      
+      float yaw = transform_direction_to_map(aw_dx, aw_dy);
       point.pose.orientation = create_quaternion_from_yaw(yaw);
     } else {
-      point.pose.orientation = create_quaternion_from_yaw(0.0);
+      point.pose.orientation = prev_orientation;
     }
 
     // 速度を計算（前の点との距離を時間間隔で割る）
@@ -484,6 +504,7 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
     // 次の計算のために現在の位置を保存
     prev_x = point.pose.position.x;
     prev_y = point.pose.position.y;
+    prev_orientation = point.pose.orientation;
 
     points.push_back(point);
   }
@@ -494,7 +515,8 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
 autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::process_candidate_trajectories(
   const std::map<int32_t, std::vector<float>> & predicted_trajectories,
   const rclcpp::Time & stamp,
-  double trajectory_timestep) const
+  double trajectory_timestep,
+  const Eigen::Matrix4f & base2map_transform) const
 {
   // CandidateTrajectories メッセージを作成
   autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories_msg;
@@ -505,12 +527,12 @@ autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::proces
     
     // ヘッダーを設定
     candidate_trajectory.header.stamp = stamp;
-    candidate_trajectory.header.frame_id = "base_link";
+    candidate_trajectory.header.frame_id = "map";
     
     // generator_idを設定（ユニークなUUID）
     candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
 
-    candidate_trajectory.points = create_trajectory_points(trajectory, trajectory_timestep);
+    candidate_trajectory.points = create_trajectory_points(trajectory, trajectory_timestep, base2map_transform);
 
     candidate_trajectories_msg.candidate_trajectories.push_back(candidate_trajectory);
 
@@ -527,15 +549,16 @@ autoware_internal_planning_msgs::msg::CandidateTrajectories VadInterface::proces
 autoware_planning_msgs::msg::Trajectory VadInterface::process_trajectory(
   const std::vector<float> & predicted_trajectory,
   const rclcpp::Time & stamp,
-  double trajectory_timestep) const
+  double trajectory_timestep,
+  const Eigen::Matrix4f & base2map_transform) const
 {
   autoware_planning_msgs::msg::Trajectory trajectory_msg;
 
   // ヘッダーを設定
   trajectory_msg.header.stamp = stamp;
-  trajectory_msg.header.frame_id = "base_link";
+  trajectory_msg.header.frame_id = "map";
 
-  trajectory_msg.points = create_trajectory_points(predicted_trajectory, trajectory_timestep);
+  trajectory_msg.points = create_trajectory_points(predicted_trajectory, trajectory_timestep, base2map_transform);
 
   return trajectory_msg;
 }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -433,6 +433,9 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
   initial_point.time_from_start.nanosec = 0;
   points.push_back(initial_point);
 
+  double prev_x = 0.0;
+  double prev_y = 0.0;
+
   for (size_t i = 0; i < predicted_trajectory.size(); i += 2) {
     autoware_planning_msgs::msg::TrajectoryPoint point;
 
@@ -451,7 +454,10 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
       point.pose.orientation = createQuaternionFromYaw(0.0);
     }
 
-    point.longitudinal_velocity_mps = 0.0;
+    // 速度を計算（前の点との距離を時間間隔で割る）
+    auto distance = std::hypot(point.pose.position.x - prev_x, point.pose.position.y - prev_y);
+    point.longitudinal_velocity_mps = static_cast<float>(distance / trajectory_timestep);
+    
     point.lateral_velocity_mps = 0.0;
     point.acceleration_mps2 = 0.0;
     point.heading_rate_rps = 0.0;
@@ -461,6 +467,10 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
     double time_sec = (point_index + 1) * trajectory_timestep;
     point.time_from_start.sec = static_cast<int32_t>(time_sec);
     point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+    // 次の計算のために現在の位置を保存
+    prev_x = point.pose.position.x;
+    prev_y = point.pose.position.y;
 
     points.push_back(point);
   }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -200,8 +200,16 @@ CameraImagesData VadInterface::process_image(
   for (int32_t autoware_idx = 0; autoware_idx < 6; ++autoware_idx) {
     const auto &image_msg = images[autoware_idx];
 
-    // OpenCVで画像データをデコード
-    cv::Mat bgr_img = cv::imdecode(cv::Mat(image_msg->data), cv::IMREAD_COLOR); // BGRでデコード
+    // sensor_msgs::msg::Image から cv::Mat を作成
+    cv::Mat bgr_img;
+    if (image_msg->encoding == "bgr8") {
+      // BGR8の場合、そのままデータを使用
+      bgr_img = cv::Mat(image_msg->height, image_msg->width, CV_8UC3, 
+                        const_cast<uint8_t*>(image_msg->data.data()), image_msg->step);
+    } else {
+      throw std::runtime_error("サポートされていない画像エンコーディング: " + image_msg->encoding);
+    }
+
     if (bgr_img.empty()) {
       throw std::runtime_error("画像データのデコードに失敗しました: " + std::to_string(autoware_idx));
     }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -399,6 +399,14 @@ std::tuple<float, float, float> VadInterface::aw2vad_xyz(float aw_x, float aw_y,
   return {vad_xyz[0], vad_xyz[1], vad_xyz[2]};
 }
 
+std::tuple<float, float, float> VadInterface::vad2aw_xyz(float vad_x, float vad_y, float vad_z) const
+{
+  // VAD base_link座標[x, y, z]をAutoware(base_link)座標に変換
+  Eigen::Vector4f vad_xyz(vad_x, vad_y, vad_z, 1.0f);
+  Eigen::Vector4f aw_xyz = vad2base_ * vad_xyz;
+  return {aw_xyz[0], aw_xyz[1], aw_xyz[2]};
+}
+
 Eigen::Quaternionf VadInterface::aw2vad_quaternion(const Eigen::Quaternionf & q_aw) const
 {
   // base2vad_の回転部分をクォータニオンに変換
@@ -450,10 +458,9 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> VadInterface::create_t
     point.pose.position.z = 0.0;
 
     if (i + 2 < predicted_trajectory.size()) {
-      float ns_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
-      float ns_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
-      float aw_dx = ns_dy;  // Autowareの座標系に変換
-      float aw_dy = -ns_dx; // Autowareの座標系に変換
+      float vad_dx = predicted_trajectory[i + 2] - predicted_trajectory[i];
+      float vad_dy = predicted_trajectory[i + 3] - predicted_trajectory[i + 1];
+      auto [aw_dx, aw_dy, aw_dz] = vad2aw_xyz(vad_dx, vad_dy, 0.0f);
       float yaw = std::atan2(aw_dy, aw_dx);
       point.pose.orientation = createQuaternionFromYaw(yaw);
     } else {

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils_uuid</depend>
+  <depend>cv_bridge</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>geometry_msgs</depend>
   <depend>libeigen3-dev</depend>

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/package.xml
@@ -15,6 +15,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils_uuid</depend>
   <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>geometry_msgs</depend>
   <depend>libeigen3-dev</depend>

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -66,20 +66,29 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
 
   // Create QoS profiles for sensor data (best effort for compatibility with typical sensor topics)
   auto sensor_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::BestEffort);
+  auto camera_info_qos = rclcpp::QoS(10).reliability(rclcpp::ReliabilityPolicy::BestEffort);
   auto reliable_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable);
 
   // Subscribers for each camera
   camera_image_subs_.resize(6);
+  std::vector<bool> use_raw_cameras = this->declare_parameter<std::vector<bool>>("node_params.use_raw", std::vector<bool>(6, false));
+  auto resolve_topic_name = [this](const std::string & query) {
+    return this->get_node_topics_interface()->resolve_topic_name(query);
+  };
   for (int32_t i = 0; i < 6; ++i) {
+    const auto transport = use_raw_cameras[i] ? "raw" : "compressed";
     auto callback =
-        [this, i](const sensor_msgs::msg::CompressedImage::SharedPtr msg) {
+        [this, i](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
           this->image_callback(msg, i);
         };
-
-    camera_image_subs_[i] =
-        this->create_subscription<sensor_msgs::msg::CompressedImage>(
-            "~/input/image" + std::to_string(i),
-            sensor_qos, callback);
+    // image_transport::create_subscription を使用
+    const auto image_topic = resolve_topic_name("~/input/image" + std::to_string(i));
+    camera_image_subs_[i] = image_transport::create_subscription(
+        this,
+        image_topic,
+        callback,
+        transport,
+        sensor_qos.get_rmw_qos_profile());
   }
 
   // Camera info subscribers
@@ -93,7 +102,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
     camera_info_subs_[i] =
         this->create_subscription<sensor_msgs::msg::CameraInfo>(
             "~/input/camera_info" + std::to_string(i),
-            sensor_qos, callback);
+            camera_info_qos, callback);
   }
 
   // Odometry subscriber (kinematic state is usually reliable)
@@ -137,7 +146,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(this->get_logger(), "VAD Node has been initialized - VAD model will be initialized after first callback");
 }
 
-void VadNode::image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg, std::size_t camera_id)
+void VadNode::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id)
 {
   // Validate camera_id
   if (camera_id >= 6) {
@@ -147,30 +156,18 @@ void VadNode::image_callback(const sensor_msgs::msg::CompressedImage::ConstShare
 
   std::lock_guard<std::mutex> lock(frame_mutex_);
 
-  try {
-    // Always use cv_bridge to properly decode compressed images
-    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    auto image_msg = cv_ptr->toImageMsg();
-    
-    // Initialize frame if not started
-    if (!frame_started_) {
-      current_frame_.stamp = msg->header.stamp;
-      frame_started_ = true;
-      // Start timeout timer for this frame
-      frame_timeout_timer_->reset();
-    }
-
-    // Store as ConstSharedPtr
-    current_frame_.images[camera_id] = std::const_pointer_cast<const sensor_msgs::msg::Image>(image_msg);
-    
-    check_and_process_frame();
-  } catch (cv_bridge::Exception& e) {
-    RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
-    return;
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(this->get_logger(), "Exception in image_callback: %s", e.what());
-    return;
+  // Initialize frame if not started
+  if (!frame_started_) {
+    current_frame_.stamp = msg->header.stamp;
+    frame_started_ = true;
+    // Start timeout timer for this frame
+    frame_timeout_timer_->reset();
   }
+
+  // Store as ConstSharedPtr directly
+  current_frame_.images[camera_id] = msg;
+    
+  check_and_process_frame();
 
   RCLCPP_DEBUG(this->get_logger(), "Received image from camera %zu", camera_id);
 }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -369,186 +369,42 @@ void VadNode::loadNetConfigs()
   vad_config_.nets_config.push_back(head_no_prev_config);
 }
 
-geometry_msgs::msg::Quaternion VadNode::createQuaternionFromYaw(double yaw)
-{
-  geometry_msgs::msg::Quaternion q{};
-  q.x = 0.0;
-  q.y = 0.0;
-  q.z = std::sin(yaw * 0.5);
-  q.w = std::cos(yaw * 0.5);
-  return q;
-}
-
-void VadNode::publishTrajectory(const std::vector<float> &planning)
-{
-  auto trajectory_msg =
-      std::make_unique<autoware_planning_msgs::msg::Trajectory>();
-
-  // 0秒目の点 (0,0) を追加
-  autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-  initial_point.pose.position.x = 0.0;
-  initial_point.pose.position.y = 0.0;
-  initial_point.pose.position.z = 0.0;
-  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
-  initial_point.longitudinal_velocity_mps = 0.0;
-  initial_point.lateral_velocity_mps = 0.0;
-  initial_point.acceleration_mps2 = 0.0;
-  initial_point.heading_rate_rps = 0.0;
-  initial_point.time_from_start.sec = 0;
-  initial_point.time_from_start.nanosec = 0;
-  trajectory_msg->points.push_back(initial_point);
-
-  for (size_t i = 0; i < planning.size(); i += 2) {
-    autoware_planning_msgs::msg::TrajectoryPoint point;
-
-    point.pose.position.x = planning[i + 1];
-    point.pose.position.y = -planning[i];
-    point.pose.position.z = 0.0;
-
-    if (i + 2 < planning.size()) {
-      float ns_dx = planning[i + 2] - planning[i];
-      float ns_dy = planning[i + 3] - planning[i + 1];
-      float aw_dx = ns_dy;  // Autowareの座標系に変換
-      float aw_dy = -ns_dx; // Autowareの座標系に変換
-      float yaw = std::atan2(aw_dy, aw_dx);
-      point.pose.orientation = createQuaternionFromYaw(yaw);
-    }
-
-    point.longitudinal_velocity_mps = 0.0;
-    point.lateral_velocity_mps = 0.0;
-    point.acceleration_mps2 = 0.0;
-    point.heading_rate_rps = 0.0;
-
-    // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
-    size_t point_index = i / 2;
-    double time_sec = (point_index + 1) * trajectory_timestep_;
-    point.time_from_start.sec = static_cast<int32_t>(time_sec);
-    point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
-
-    trajectory_msg->points.push_back(point);
-  }
-
-  trajectory_msg->header.stamp = this->now();
-  trajectory_msg->header.frame_id = "base_link";
-
-  trajectory_publisher_->publish(std::move(trajectory_msg));
-}
-
-autoware_internal_planning_msgs::msg::CandidateTrajectories VadNode::convert_candidate_trajectories(const std::map<int32_t, std::vector<float>> &trajectories_map)
-{
-  // CandidateTrajectories メッセージを作成
-  autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories_msg;
-
-  // 各コマンドの軌道をCandidateTrajectoryとして追加
-  for (const auto& [command_idx, trajectory] : trajectories_map) {
-    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
-    
-    // ヘッダーを設定
-    candidate_trajectory.header.stamp = this->now();
-    candidate_trajectory.header.frame_id = "base_link";
-    
-    // generator_idを設定（ユニークなUUID）
-    candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
-
-    // 0秒目の点 (0,0) を追加
-    autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-    initial_point.pose.position.x = 0.0;
-    initial_point.pose.position.y = 0.0;
-    initial_point.pose.position.z = 0.0;
-    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
-    initial_point.longitudinal_velocity_mps = 0.0;
-    initial_point.lateral_velocity_mps = 0.0;
-    initial_point.acceleration_mps2 = 0.0;
-    initial_point.heading_rate_rps = 0.0;
-    initial_point.time_from_start.sec = 0;
-    initial_point.time_from_start.nanosec = 0;
-    candidate_trajectory.points.push_back(initial_point);
-
-    for (size_t i = 0; i < trajectory.size(); i += 2) {
-      autoware_planning_msgs::msg::TrajectoryPoint point;
-
-      point.pose.position.x = trajectory[i + 1];
-      point.pose.position.y = -trajectory[i];
-      point.pose.position.z = 0.0;
-
-      if (i + 2 < trajectory.size()) {
-        float ns_dx = trajectory[i + 2] - trajectory[i];
-        float ns_dy = trajectory[i + 3] - trajectory[i + 1];
-        float aw_dx = ns_dy;  // Autowareの座標系に変換
-        float aw_dy = -ns_dx; // Autowareの座標系に変換
-        float yaw = std::atan2(aw_dy, aw_dx);
-        point.pose.orientation = createQuaternionFromYaw(yaw);
-      }
-
-      point.longitudinal_velocity_mps = 0.0;
-      point.lateral_velocity_mps = 0.0;
-      point.acceleration_mps2 = 0.0;
-      point.heading_rate_rps = 0.0;
-
-      // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
-      size_t point_index = i / 2;
-      double time_sec = (point_index + 1) * trajectory_timestep_;
-      point.time_from_start.sec = static_cast<int32_t>(time_sec);
-      point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
-
-      candidate_trajectory.points.push_back(point);
-    }
-
-    candidate_trajectories_msg.candidate_trajectories.push_back(candidate_trajectory);
-
-    // 各コマンドのGeneratorInfoを追加
-    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
-    generator_info.generator_id = autoware_utils_uuid::generate_uuid();
-    generator_info.generator_name.data = "autoware_tensorrt_vad_cmd_" + std::to_string(command_idx);
-    candidate_trajectories_msg.generator_info.push_back(generator_info);
-  }
-
-  return candidate_trajectories_msg;
-}
-
 void VadNode::publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)
 {
   auto candidate_trajectories_msg = std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories);
   candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
 }
 
-std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> VadNode::execute_inference(const VadInputTopicData & vad_topic_data)
+void VadNode::publishTrajectory(const autoware_planning_msgs::msg::Trajectory & trajectory)
+{
+  auto trajectory_msg = std::make_unique<autoware_planning_msgs::msg::Trajectory>(trajectory);
+  trajectory_publisher_->publish(std::move(trajectory_msg));
+}
+
+std::optional<VadOutputTopicData> VadNode::execute_inference(const VadInputTopicData & vad_topic_data)
 {
   if (!vad_interface_ptr_ || !vad_model_ptr_) {
     RCLCPP_ERROR(this->get_logger(), "VAD interface or model not initialized");
     return std::nullopt;
   }
 
-  try {
-    // VadInterfaceを通じてVadInputDataに変換
-    // scalingされた状態の画像を含む
-    const auto vad_input = vad_interface_ptr_->convert_input(vad_topic_data, prev_can_bus_);
+  // VadInterfaceを通じてVadInputDataに変換
+  // scalingされた状態の画像を含む
+  const auto vad_input = vad_interface_ptr_->convert_input(vad_topic_data, prev_can_bus_);
 
-    // VadModelで推論実行
-    const auto vad_output = vad_model_ptr_->infer(vad_input);
+  // VadModelで推論実行
+  const auto vad_output = vad_model_ptr_->infer(vad_input);
 
-    // VadInterfaceを通じてROS型に変換
-    if (vad_output.has_value()) {
-      // Update prev_can_bus for next frame
-      prev_can_bus_ = vad_input.can_bus_;
+  // VadInterfaceを通じてROS型に変換
+  if (vad_output.has_value()) {
+    const auto vad_output_topic_data = vad_interface_ptr_->convert_output(
+      *vad_output, this->now(), trajectory_timestep_);
 
-      // Publish individual trajectory if available
-      if (!vad_output->predicted_trajectory_.empty()) {
-        publishTrajectory(vad_output->predicted_trajectory_);
-      }
+    // Update prev_can_bus for next frame
+    prev_can_bus_ = vad_input.can_bus_;
 
-      // Convert candidate trajectories if available
-      if (!vad_output->predicted_trajectories_.empty()) {
-        auto candidate_trajectories_msg = convert_candidate_trajectories(vad_output->predicted_trajectories_);
-        return std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories_msg);
-      }
-
-      // Return empty message if no trajectories available
-      auto candidate_trajectories_msg = autoware_internal_planning_msgs::msg::CandidateTrajectories();
-      return std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories_msg);
-    }
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(this->get_logger(), "Error during inference: %s", e.what());
+    // Return VadOutputTopicData
+    return vad_output_topic_data;
   }
 
   return std::nullopt;
@@ -556,19 +412,21 @@ std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> VadNo
 
 void VadNode::publish(const VadInputTopicData & vad_topic_data)
 {
-  try {
-    // VAD推論を実行
-    const auto candidate_trajectories_msg = execute_inference(vad_topic_data);
 
-    // 結果をパブリッシュ
-    if (candidate_trajectories_msg.has_value()) {
-      publishTrajectories(candidate_trajectories_msg.value());
-      RCLCPP_DEBUG(this->get_logger(), "Published candidate trajectories");
-    } else {
-      RCLCPP_WARN(this->get_logger(), "No valid trajectories to publish");
-    }
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(this->get_logger(), "Error in publish method: %s", e.what());
+  // VAD推論を実行
+  const auto vad_output_topic_data = execute_inference(vad_topic_data);
+
+  // 結果をパブリッシュ
+  if (vad_output_topic_data.has_value()) {
+    // Publish individual trajectory using the dedicated method
+    publishTrajectory(vad_output_topic_data.value().trajectory);
+
+    // Publish candidate trajectories
+    publishTrajectories(vad_output_topic_data.value().candidate_trajectories);
+
+    RCLCPP_DEBUG(this->get_logger(), "Published trajectories and candidate trajectories");
+  } else {
+    RCLCPP_WARN(this->get_logger(), "No valid trajectories to publish");
   }
 }
 

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -264,16 +264,6 @@ void VadNode::check_and_process_frame()
     if (vad_model_ptr_) {
       // Execute inference and publish results
       publish(current_frame_);
-      
-      // Update prev_can_bus for next frame if we have one
-      if (current_frame_.kinematic_state && current_frame_.imu_raw) {
-        // Update prev_can_bus based on current odometry/IMU data
-        // This is a simplified version - real implementation would convert properly
-        prev_can_bus_.clear();
-        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.linear.x));
-        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.linear.y));
-        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.angular.z));
-      }
     }
 
     // Reset frame for next data collection

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -75,6 +75,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       declare_parameter<double>("interface_params.default_patch_angle"),
       declare_parameter<int32_t>("model_params.default_command"),
       declare_parameter<std::vector<double>>("interface_params.default_shift"),
+      declare_parameter<std::vector<double>>("interface_params.default_can_bus"),
       declare_parameter<std::vector<double>>("interface_params.image_normalization_param_mean"),
       declare_parameter<std::vector<double>>("interface_params.image_normalization_param_std"),
       declare_parameter<std::vector<double>>("interface_params.vad2base"),
@@ -86,11 +87,6 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
     current_frame_(num_cameras_),
     frame_started_(false)
 {
-  // Initialize prev_can_bus from parameters
-  std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
-  prev_can_bus_.clear();
-  for (auto v : default_can_bus) prev_can_bus_.push_back(static_cast<float>(v));
-
   // Publishers
   trajectory_publisher_ =
       this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
@@ -417,7 +413,7 @@ std::optional<VadOutputTopicData> VadNode::execute_inference(const VadInputTopic
 
   // VadInterfaceを通じてVadInputDataに変換
   // scalingされた状態の画像を含む
-  const auto vad_input = vad_interface_ptr_->convert_input(vad_topic_data, prev_can_bus_);
+  const auto vad_input = vad_interface_ptr_->convert_input(vad_topic_data);
 
   // VadModelで推論実行
   const auto vad_output = vad_model_ptr_->infer(vad_input);
@@ -427,10 +423,6 @@ std::optional<VadOutputTopicData> VadNode::execute_inference(const VadInputTopic
   if (vad_output.has_value()) {
     const auto vad_output_topic_data = vad_interface_ptr_->convert_output(
       *vad_output, this->now(), trajectory_timestep_, base2map_transform);
-
-    // Update prev_can_bus for next frame
-    prev_can_bus_ = vad_input.can_bus_;
-
     // Return VadOutputTopicData
     return vad_output_topic_data;
   }

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -17,12 +17,368 @@
 #include "autoware/tensorrt_vad/utils.hpp"
 
 #include <rclcpp_components/register_node_macro.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.hpp>
 
 namespace autoware::tensorrt_vad
 {
 
-// ヘルパー関数：yaw角からクォータニオンを作成
-geometry_msgs::msg::Quaternion calculate_quaternion_from_yaw(double yaw)
+VadNode::VadNode(const rclcpp::NodeOptions & options) 
+  : Node("vad_node", options), 
+    vad_interface_config_(
+      declare_parameter<int32_t>("interface_params.input_image_width"),
+      declare_parameter<int32_t>("interface_params.input_image_height"),
+      declare_parameter<int32_t>("interface_params.target_image_width"),
+      declare_parameter<int32_t>("interface_params.target_image_height"),
+      declare_parameter<std::vector<double>>("interface_params.point_cloud_range"),
+      declare_parameter<int32_t>("interface_params.bev_h"),
+      declare_parameter<int32_t>("interface_params.bev_w"),
+      declare_parameter<double>("interface_params.default_patch_angle"),
+      declare_parameter<int32_t>("model_params.default_command"),
+      declare_parameter<std::vector<double>>("interface_params.default_shift"),
+      declare_parameter<std::vector<double>>("interface_params.image_normalization_param_mean"),
+      declare_parameter<std::vector<double>>("interface_params.image_normalization_param_std"),
+      declare_parameter<std::vector<double>>("interface_params.vad2base"),
+      declare_parameter<std::vector<int64_t>>("interface_params.autoware_to_vad_camera_mapping")
+    ),
+    tf_buffer_(this->get_clock()),
+    trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0)),
+    frame_started_(false)
+{
+  // Initialize prev_can_bus from parameters like in main.cpp
+  std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
+  prev_can_bus_.clear();
+  for (auto v : default_can_bus) prev_can_bus_.push_back(static_cast<float>(v));
+
+  // Publishers like in main.cpp - use output remapping from launch file
+  trajectory_publisher_ =
+      this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
+          "~/output/trajectory", rclcpp::QoS(1));
+
+  candidate_trajectories_publisher_ =
+      this->create_publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
+          "~/output/trajectories", rclcpp::QoS(1));
+
+  objects_publisher_ =
+      this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+          "~/output/objects",
+          rclcpp::QoS(1));
+
+  // Subscribers for each camera like in main.cpp
+  camera_image_subs_.resize(6);
+  for (int32_t i = 0; i < 6; ++i) {
+    auto callback =
+        [this, i](const sensor_msgs::msg::CompressedImage::SharedPtr msg) {
+          this->image_callback(msg, i);
+        };
+
+    camera_image_subs_[i] =
+        this->create_subscription<sensor_msgs::msg::CompressedImage>(
+            "~/input/image" + std::to_string(i),
+            rclcpp::QoS(1), callback);
+  }
+
+  // Camera info subscribers
+  camera_info_subs_.resize(6);
+  for (int32_t i = 0; i < 6; ++i) {
+    auto callback =
+        [this, i](const sensor_msgs::msg::CameraInfo::SharedPtr msg) {
+          this->camera_info_callback(msg, i);
+        };
+
+    camera_info_subs_[i] =
+        this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            "~/input/camera_info" + std::to_string(i),
+            rclcpp::QoS(1), callback);
+  }
+
+  // Odometry subscriber like in extract_vad_topic_data_from_rosbag
+  odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "/localization/kinematic_state", rclcpp::QoS(1),
+      std::bind(&VadNode::odometry_callback, this, std::placeholders::_1));
+
+  // IMU subscriber like in extract_vad_topic_data_from_rosbag
+  imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "/sensing/imu/tamagawa/imu_raw", rclcpp::QoS(1),
+      std::bind(&VadNode::imu_callback, this, std::placeholders::_1));
+
+  // TF static subscriber
+  tf_static_sub_ = this->create_subscription<tf2_msgs::msg::TFMessage>(
+      "/tf_static", rclcpp::QoS(1),
+      std::bind(&VadNode::tf_static_callback, this, std::placeholders::_1));
+
+  // Load VadConfig like in main.cpp
+  loadVadConfig();
+
+  // Initialize current frame structure
+  current_frame_.images.resize(6);
+  current_frame_.camera_infos.resize(6);
+
+  // Initialize timeout timer
+  frame_timeout_timer_ = this->create_wall_timer(
+    FRAME_TIMEOUT,
+    std::bind(&VadNode::frame_timeout_callback, this));
+  
+  // Start timer as stopped initially
+  frame_timeout_timer_->cancel();
+
+  RCLCPP_INFO(this->get_logger(), "VAD Node has been initialized - VAD model will be initialized after first callback");
+}
+
+void VadNode::image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg, std::size_t camera_id)
+{
+  // Validate camera_id
+  if (camera_id >= 6) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-5", camera_id);
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+
+  try {
+    // Always use cv_bridge to properly decode compressed images
+    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+    auto image_msg = cv_ptr->toImageMsg();
+    
+    // Initialize frame if not started
+    if (!frame_started_) {
+      current_frame_.stamp = msg->header.stamp;
+      frame_started_ = true;
+      // Start timeout timer for this frame
+      frame_timeout_timer_->reset();
+    }
+
+    // Store as ConstSharedPtr
+    current_frame_.images[camera_id] = std::const_pointer_cast<const sensor_msgs::msg::Image>(image_msg);
+    
+    check_and_process_frame();
+  } catch (cv_bridge::Exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
+    return;
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "Exception in image_callback: %s", e.what());
+    return;
+  }
+
+  RCLCPP_DEBUG(this->get_logger(), "Received image from camera %zu", camera_id);
+}
+
+void VadNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id)
+{
+  // Validate camera_id
+  if (camera_id >= 6) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-5", camera_id);
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+
+  // Initialize frame if not started
+  if (!frame_started_) {
+    current_frame_.stamp = msg->header.stamp;
+    frame_started_ = true;
+    // Start timeout timer for this frame
+    frame_timeout_timer_->reset();
+  }
+
+  current_frame_.camera_infos[camera_id] = msg;
+  check_and_process_frame();
+
+  RCLCPP_DEBUG(this->get_logger(), "Received camera info from camera %zu", camera_id);
+}
+
+void VadNode::odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+
+  // Initialize frame if not started
+  if (!frame_started_) {
+    current_frame_.stamp = msg->header.stamp;
+    frame_started_ = true;
+    // Start timeout timer for this frame
+    frame_timeout_timer_->reset();
+  }
+
+  current_frame_.kinematic_state = msg;
+  check_and_process_frame();
+
+  RCLCPP_DEBUG(this->get_logger(), "Received odometry data");
+}
+
+void VadNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+
+  // Initialize frame if not started
+  if (!frame_started_) {
+    current_frame_.stamp = msg->header.stamp;
+    frame_started_ = true;
+    // Start timeout timer for this frame
+    frame_timeout_timer_->reset();
+  }
+
+  current_frame_.imu_raw = msg;
+  check_and_process_frame();
+
+  RCLCPP_DEBUG(this->get_logger(), "Received IMU data");
+}
+
+void VadNode::tf_static_callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+
+  // Initialize frame if not started (though tf_static typically comes first)
+  if (!frame_started_) {
+    current_frame_.stamp = rclcpp::Time(0);  // tf_static doesn't have timestamp
+    frame_started_ = true;
+    // Start timeout timer for this frame
+    frame_timeout_timer_->reset();
+  }
+
+  current_frame_.tf_static = msg;
+
+  // Register transforms in tf_buffer like in main.cpp
+  for (const auto &transform : msg->transforms) {
+    tf_buffer_.setTransform(transform, "default_authority", true);
+  }
+
+  check_and_process_frame();
+
+  RCLCPP_DEBUG(this->get_logger(), "Received TF static data");
+}
+
+void VadNode::check_and_process_frame()
+{
+  // Use the built-in is_complete() method to check if we have all required data
+  if (current_frame_.is_complete()) {
+    
+    // Cancel timeout timer since frame is complete
+    frame_timeout_timer_->cancel();
+    
+    // Initialize VAD model on first complete frame
+    if (!vad_model_ptr_) {
+      RCLCPP_INFO(this->get_logger(), "Initializing VAD model with first complete frame");
+      initializeVadModel();
+    }
+
+    if (vad_model_ptr_) {
+      // Execute inference and publish results
+      publish(current_frame_);
+      
+      // Update prev_can_bus for next frame if we have one
+      if (current_frame_.kinematic_state && current_frame_.imu_raw) {
+        // Update prev_can_bus based on current odometry/IMU data
+        // This is a simplified version - real implementation would convert properly
+        prev_can_bus_.clear();
+        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.linear.x));
+        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.linear.y));
+        prev_can_bus_.push_back(static_cast<float>(current_frame_.kinematic_state->twist.twist.angular.z));
+      }
+    }
+
+    // Reset frame for next data collection
+    reset_current_frame();
+  }
+}
+
+void VadNode::reset_current_frame()
+{
+  current_frame_.images.clear();
+  current_frame_.images.resize(6);
+  current_frame_.camera_infos.clear();
+  current_frame_.camera_infos.resize(6);
+  current_frame_.kinematic_state.reset();
+  current_frame_.imu_raw.reset();
+  current_frame_.tf_static.reset();
+  frame_started_ = false;
+}
+
+void VadNode::initializeVadModel()
+{
+  try {
+    // Initialize VAD interface and model like in main.cpp
+    auto tf_buffer_shared = std::shared_ptr<tf2_ros::Buffer>(&tf_buffer_, [](tf2_ros::Buffer*){});
+    vad_interface_ptr_ = std::make_unique<VadInterface>(vad_interface_config_, tf_buffer_shared);
+    
+    // Create RosVadLogger using the logger directly (no shared_from_this needed)
+    auto ros_logger = std::make_shared<RosVadLogger>(this->get_logger());
+    vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_config_, ros_logger);
+    
+    RCLCPP_INFO(this->get_logger(), "VAD model and interface initialized successfully");
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to initialize VAD model: %s", e.what());
+  }
+}
+
+void VadNode::loadVadConfig()
+{
+  // Load VAD config parameters like in main.cpp
+  vad_config_.plugins_path =
+      this->declare_parameter<std::string>("model_params.plugins_path", "");
+  vad_config_.warm_up_num =
+      this->declare_parameter<int>("model_params.warm_up_num", 20);
+
+  // Load network configurations
+  loadNetConfigs();
+}
+
+void VadNode::loadNetConfigs()
+{
+  // Load network configurations like in main.cpp
+  
+  // backbone configuration
+  NetConfig backbone_config;
+  backbone_config.name = this->declare_parameter<std::string>(
+      "model_params.nets.backbone.name", "backbone");
+  backbone_config.engine_file = this->declare_parameter<std::string>(
+      "model_params.nets.backbone.engine_file", "");
+  backbone_config.use_graph = this->declare_parameter<bool>(
+      "model_params.nets.backbone.use_graph", true);
+
+  // head configuration
+  NetConfig head_config;
+  head_config.name = this->declare_parameter<std::string>(
+      "model_params.nets.head.name", "head");
+  head_config.engine_file = this->declare_parameter<std::string>(
+      "model_params.nets.head.engine_file", "");
+  head_config.use_graph = this->declare_parameter<bool>(
+      "model_params.nets.head.use_graph", true);
+
+  // head inputs
+  std::string input_feature = this->declare_parameter<std::string>(
+      "model_params.nets.head.inputs.input_feature", "mlvl_feats.0");
+  std::string net_param = this->declare_parameter<std::string>(
+      "model_params.nets.head.inputs.net", "backbone");
+  std::string name_param = this->declare_parameter<std::string>(
+      "model_params.nets.head.inputs.name", "out.0");
+  head_config.inputs[input_feature]["net"] = net_param;
+  head_config.inputs[input_feature]["name"] = name_param;
+
+  // head_no_prev configuration
+  NetConfig head_no_prev_config;
+  head_no_prev_config.name = this->declare_parameter<std::string>(
+      "model_params.nets.head_no_prev.name", "head_no_prev");
+  head_no_prev_config.engine_file = this->declare_parameter<std::string>(
+      "model_params.nets.head_no_prev.engine_file", "");
+  head_no_prev_config.use_graph = this->declare_parameter<bool>(
+      "model_params.nets.head_no_prev.use_graph", true);
+
+  // head_no_prev inputs
+  std::string input_feature_no_prev = this->declare_parameter<std::string>(
+      "model_params.nets.head_no_prev.inputs.input_feature", "mlvl_feats.0");
+  std::string net_param_no_prev = this->declare_parameter<std::string>(
+      "model_params.nets.head_no_prev.inputs.net", "backbone");
+  std::string name_param_no_prev = this->declare_parameter<std::string>(
+      "model_params.nets.head_no_prev.inputs.name", "out.0");
+  head_no_prev_config.inputs[input_feature_no_prev]["net"] = net_param_no_prev;
+  head_no_prev_config.inputs[input_feature_no_prev]["name"] = name_param_no_prev;
+
+  vad_config_.nets_config.push_back(backbone_config);
+  vad_config_.nets_config.push_back(head_config);
+  vad_config_.nets_config.push_back(head_no_prev_config);
+}
+
+geometry_msgs::msg::Quaternion VadNode::createQuaternionFromYaw(double yaw)
 {
   geometry_msgs::msg::Quaternion q{};
   q.x = 0.0;
@@ -32,31 +388,222 @@ geometry_msgs::msg::Quaternion calculate_quaternion_from_yaw(double yaw)
   return q;
 }
 
-VadNode::VadNode(const rclcpp::NodeOptions & options) : Node("vad_node", options), tf_buffer_(this->get_clock())
+void VadNode::publishTrajectory(const std::vector<float> &planning)
 {
-  // Publishers の初期化
-  trajectory_pub_ = this->create_publisher<autoware_planning_msgs::msg::Trajectory>("~/output/trajectory", rclcpp::QoS(1));
+  auto trajectory_msg =
+      std::make_unique<autoware_planning_msgs::msg::Trajectory>();
 
-  // VADモデルの初期化 - 一時的にコメントアウト
-  // TODO: 適切な設定ファイルとロガーを用意してから初期化
-  // auto logger = std::make_shared<RosVadLogger>();
-  // VadConfig config;
-  // vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(config, logger);
+  // 0秒目の点 (0,0) を追加
+  autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+  initial_point.pose.position.x = 0.0;
+  initial_point.pose.position.y = 0.0;
+  initial_point.pose.position.z = 0.0;
+  initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+  initial_point.longitudinal_velocity_mps = 0.0;
+  initial_point.lateral_velocity_mps = 0.0;
+  initial_point.acceleration_mps2 = 0.0;
+  initial_point.heading_rate_rps = 0.0;
+  initial_point.time_from_start.sec = 0;
+  initial_point.time_from_start.nanosec = 0;
+  trajectory_msg->points.push_back(initial_point);
 
-  RCLCPP_INFO(this->get_logger(), "VAD Node initialized");
+  for (size_t i = 0; i < planning.size(); i += 2) {
+    autoware_planning_msgs::msg::TrajectoryPoint point;
+
+    point.pose.position.x = planning[i + 1];
+    point.pose.position.y = -planning[i];
+    point.pose.position.z = 0.0;
+
+    if (i + 2 < planning.size()) {
+      float ns_dx = planning[i + 2] - planning[i];
+      float ns_dy = planning[i + 3] - planning[i + 1];
+      float aw_dx = ns_dy;  // Autowareの座標系に変換
+      float aw_dy = -ns_dx; // Autowareの座標系に変換
+      float yaw = std::atan2(aw_dy, aw_dx);
+      point.pose.orientation = createQuaternionFromYaw(yaw);
+    }
+
+    point.longitudinal_velocity_mps = 0.0;
+    point.lateral_velocity_mps = 0.0;
+    point.acceleration_mps2 = 0.0;
+    point.heading_rate_rps = 0.0;
+
+    // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+    size_t point_index = i / 2;
+    double time_sec = (point_index + 1) * trajectory_timestep_;
+    point.time_from_start.sec = static_cast<int32_t>(time_sec);
+    point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+    trajectory_msg->points.push_back(point);
+  }
+
+  trajectory_msg->header.stamp = this->now();
+  trajectory_msg->header.frame_id = "base_link";
+
+  trajectory_publisher_->publish(std::move(trajectory_msg));
 }
 
-// std::tuple<std::optional<autoware_planning_msgs::msg::Trajectory>, std::optional<autoware_perception_msgs::msg::DetectedObjects> > execute_inference(const VadInputTopicData vad_topic_data)
-// {
-//   // VadInterfaceを通じてVadInputDataに変換
-//   // scalingされた状態の画像を含む
-//   const auto vad_input = vad_interface_ptr_->convert_ros_to_vad_input(vad_topic_data);
+void VadNode::publishTrajectories(const std::map<int32_t, std::vector<float>> &trajectories_map)
+{
+  // CandidateTrajectories メッセージを作成
+  auto candidate_trajectories_msg =
+      std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
 
-//   // VadModelで推論実行
-//   const auto vad_output = vad_model_ptr_->infer(vad_input);
+  // 各コマンドの軌道をCandidateTrajectoryとして追加
+  for (const auto& [command_idx, trajectory] : trajectories_map) {
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    
+    // ヘッダーを設定
+    candidate_trajectory.header.stamp = this->now();
+    candidate_trajectory.header.frame_id = "base_link";
+    
+    // generator_idを設定（ユニークなUUID）
+    candidate_trajectory.generator_id = autoware_utils_uuid::generate_uuid();
 
-//   // VadInterfaceを通じてROS型に変換
-//   return vad_interface_ptr_->convert_vad_output_to_ros(vad_output);
+    // 0秒目の点 (0,0) を追加
+    autoware_planning_msgs::msg::TrajectoryPoint initial_point;
+    initial_point.pose.position.x = 0.0;
+    initial_point.pose.position.y = 0.0;
+    initial_point.pose.position.z = 0.0;
+    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+    initial_point.longitudinal_velocity_mps = 0.0;
+    initial_point.lateral_velocity_mps = 0.0;
+    initial_point.acceleration_mps2 = 0.0;
+    initial_point.heading_rate_rps = 0.0;
+    initial_point.time_from_start.sec = 0;
+    initial_point.time_from_start.nanosec = 0;
+    candidate_trajectory.points.push_back(initial_point);
+
+    for (size_t i = 0; i < trajectory.size(); i += 2) {
+      autoware_planning_msgs::msg::TrajectoryPoint point;
+
+      point.pose.position.x = trajectory[i + 1];
+      point.pose.position.y = -trajectory[i];
+      point.pose.position.z = 0.0;
+
+      if (i + 2 < trajectory.size()) {
+        float ns_dx = trajectory[i + 2] - trajectory[i];
+        float ns_dy = trajectory[i + 3] - trajectory[i + 1];
+        float aw_dx = ns_dy;  // Autowareの座標系に変換
+        float aw_dy = -ns_dx; // Autowareの座標系に変換
+        float yaw = std::atan2(aw_dy, aw_dx);
+        point.pose.orientation = createQuaternionFromYaw(yaw);
+      }
+
+      point.longitudinal_velocity_mps = 0.0;
+      point.lateral_velocity_mps = 0.0;
+      point.acceleration_mps2 = 0.0;
+      point.heading_rate_rps = 0.0;
+
+      // time_from_startを設定（1秒, 2秒, 3秒, 4秒, 5秒, 6秒）
+      size_t point_index = i / 2;
+      double time_sec = (point_index + 1) * trajectory_timestep_;
+      point.time_from_start.sec = static_cast<int32_t>(time_sec);
+      point.time_from_start.nanosec = static_cast<uint32_t>((time_sec - point.time_from_start.sec) * 1e9);
+
+      candidate_trajectory.points.push_back(point);
+    }
+
+    candidate_trajectories_msg->candidate_trajectories.push_back(candidate_trajectory);
+
+    // 各コマンドのGeneratorInfoを追加
+    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+    generator_info.generator_id = autoware_utils_uuid::generate_uuid();
+    generator_info.generator_name.data = "autoware_tensorrt_vad_cmd_" + std::to_string(command_idx);
+    candidate_trajectories_msg->generator_info.push_back(generator_info);
+  }
+
+  candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
+}
+
+std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> VadNode::execute_inference(const VadInputTopicData & vad_topic_data)
+{
+  if (!vad_interface_ptr_ || !vad_model_ptr_) {
+    RCLCPP_ERROR(this->get_logger(), "VAD interface or model not initialized");
+    return std::nullopt;
+  }
+
+  try {
+    // VadInterfaceを通じてVadInputDataに変換
+    // scalingされた状態の画像を含む
+    const auto vad_input = vad_interface_ptr_->convert_input(vad_topic_data, prev_can_bus_);
+
+    // VadModelで推論実行
+    const auto vad_output = vad_model_ptr_->infer(vad_input);
+
+    // VadInterfaceを通じてROS型に変換
+    if (vad_output.has_value()) {
+      // Update prev_can_bus for next frame
+      prev_can_bus_ = vad_input.can_bus_;
+
+      // Publish individual trajectory if available
+      if (!vad_output->predicted_trajectory_.empty()) {
+        publishTrajectory(vad_output->predicted_trajectory_);
+      }
+
+      // Publish candidate trajectories if available
+      if (!vad_output->predicted_trajectories_.empty()) {
+        publishTrajectories(vad_output->predicted_trajectories_);
+      }
+
+      // Return a simple success indicator - we already published the data above
+      auto candidate_trajectories_msg = autoware_internal_planning_msgs::msg::CandidateTrajectories();
+      return std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories_msg);
+    }
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "Error during inference: %s", e.what());
+  }
+
+  return std::nullopt;
+}
+
+void VadNode::publish(const VadInputTopicData & vad_topic_data)
+{
+  try {
+    // VAD推論を実行
+    const auto candidate_trajectories_msg = execute_inference(vad_topic_data);
+
+    // 結果をパブリッシュ
+    if (candidate_trajectories_msg.has_value()) {
+      // We already published in execute_inference, just log success
+      RCLCPP_DEBUG(this->get_logger(), "Published candidate trajectories");
+    } else {
+      RCLCPP_WARN(this->get_logger(), "No valid trajectories to publish");
+    }
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "Error in publish method: %s", e.what());
+  }
+}
+
+void VadNode::frame_timeout_callback()
+{
+  std::lock_guard<std::mutex> lock(frame_mutex_);
+  
+  if (frame_started_) {
+    // Check how much data we have
+    int valid_images = 0;
+    int valid_camera_infos = 0;
+    
+    for (size_t i = 0; i < current_frame_.images.size(); ++i) {
+      if (current_frame_.images[i]) valid_images++;
+      if (current_frame_.camera_infos[i]) valid_camera_infos++;
+    }
+    
+    RCLCPP_WARN(this->get_logger(), 
+                "Frame timeout reached. Have %d/%d images, %d/%d camera_infos, kinematic_state: %s, imu_raw: %s, tf_static: %s",
+                valid_images, 6, valid_camera_infos, 6,
+                current_frame_.kinematic_state ? "yes" : "no",
+                current_frame_.imu_raw ? "yes" : "no",
+                current_frame_.tf_static ? "yes" : "no");
+    
+    // Reset frame if incomplete
+    reset_current_frame();
+  }
+  
+  // Stop timer until next frame starts
+  frame_timeout_timer_->cancel();
+}
+
 }  // namespace autoware::tensorrt_vad
 
 // Register the component with the ROS2 component system

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -107,40 +107,10 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   auto reliable_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable);
 
   // Subscribers for each camera
-  camera_image_subs_.resize(num_cameras_);
-  std::vector<bool> use_raw_cameras = this->declare_parameter<std::vector<bool>>("node_params.use_raw", std::vector<bool>(num_cameras_, false));
-  auto resolve_topic_name = [this](const std::string & query) {
-    return this->get_node_topics_interface()->resolve_topic_name(query);
-  };
-  for (int32_t i = 0; i < num_cameras_; ++i) {
-    const auto transport = use_raw_cameras[i] ? "raw" : "compressed";
-    auto callback =
-        [this, i](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
-          this->image_callback(msg, i);
-        };
-    // image_transport::create_subscription を使用
-    const auto image_topic = resolve_topic_name("~/input/image" + std::to_string(i));
-    camera_image_subs_[i] = image_transport::create_subscription(
-        this,
-        image_topic,
-        callback,
-        transport,
-        sensor_qos.get_rmw_qos_profile());
-  }
+  create_camera_image_subscribers(sensor_qos);
 
-  // Camera info subscribers
-  camera_info_subs_.resize(num_cameras_);
-  for (int32_t i = 0; i < num_cameras_; ++i) {
-    auto callback =
-        [this, i](const sensor_msgs::msg::CameraInfo::SharedPtr msg) {
-          this->camera_info_callback(msg, i);
-        };
-
-    camera_info_subs_[i] =
-        this->create_subscription<sensor_msgs::msg::CameraInfo>(
-            "~/input/camera_info" + std::to_string(i),
-            camera_info_qos, callback);
-  }
+  // Subscribers for camera info
+  create_camera_info_subscribers(camera_info_qos);
 
   // Odometry subscriber (kinematic state is usually reliable)
   odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
@@ -477,6 +447,46 @@ void VadNode::frame_timeout_callback()
   
   // Stop timer until next frame starts
   frame_timeout_timer_->cancel();
+}
+
+void VadNode::create_camera_image_subscribers(const rclcpp::QoS& sensor_qos)
+{
+  camera_image_subs_.resize(num_cameras_);
+  std::vector<bool> use_raw_cameras = this->declare_parameter<std::vector<bool>>("node_params.use_raw", std::vector<bool>(num_cameras_, false));
+  auto resolve_topic_name = [this](const std::string & query) {
+    return this->get_node_topics_interface()->resolve_topic_name(query);
+  };
+  for (int32_t i = 0; i < num_cameras_; ++i) {
+    const auto transport = use_raw_cameras[i] ? "raw" : "compressed";
+    auto callback =
+        [this, i](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
+          this->image_callback(msg, i);
+        };
+    // image_transport::create_subscription を使用
+    const auto image_topic = resolve_topic_name("~/input/image" + std::to_string(i));
+    camera_image_subs_[i] = image_transport::create_subscription(
+        this,
+        image_topic,
+        callback,
+        transport,
+        sensor_qos.get_rmw_qos_profile());
+  }
+}
+
+void VadNode::create_camera_info_subscribers(const rclcpp::QoS& camera_info_qos)
+{
+  camera_info_subs_.resize(num_cameras_);
+  for (int32_t i = 0; i < num_cameras_; ++i) {
+    auto callback =
+        [this, i](const sensor_msgs::msg::CameraInfo::SharedPtr msg) {
+          this->camera_info_callback(msg, i);
+        };
+
+    camera_info_subs_[i] =
+        this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            "~/input/camera_info" + std::to_string(i),
+            camera_info_qos, callback);
+  }
 }
 
 }  // namespace autoware::tensorrt_vad

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -22,6 +22,45 @@
 
 namespace autoware::tensorrt_vad
 {
+std::pair<Eigen::Matrix4f, Eigen::Matrix4f> get_transform_matrix(
+  const nav_msgs::msg::Odometry & msg)
+{
+  // Extract position
+  double x = msg.pose.pose.position.x;
+  double y = msg.pose.pose.position.y;
+  double z = msg.pose.pose.position.z;
+
+  // Create Eigen quaternion and normalize it just in case
+  Eigen::Quaternionf q = std::invoke([&msg]() -> Eigen::Quaternionf {
+    double qx = msg.pose.pose.orientation.x;
+    double qy = msg.pose.pose.orientation.y;
+    double qz = msg.pose.pose.orientation.z;
+    double qw = msg.pose.pose.orientation.w;
+
+    // Create Eigen quaternion and normalize it just in case
+    Eigen::Quaternionf q(qw, qx, qy, qz);
+    return (q.norm() < std::numeric_limits<float>::epsilon()) ? Eigen::Quaternionf::Identity()
+                                                              : q.normalized();
+  });
+
+  // Rotation matrix (3x3)
+  Eigen::Matrix3f R = q.toRotationMatrix();
+
+  // Translation vector
+  Eigen::Vector3f t(x, y, z);
+
+  // Base_link → Map (forward)
+  Eigen::Matrix4f bl2map = Eigen::Matrix4f::Identity();
+  bl2map.block<3, 3>(0, 0) = R;
+  bl2map.block<3, 1>(0, 3) = t;
+
+  // Map → Base_link (inverse)
+  Eigen::Matrix4f map2bl = Eigen::Matrix4f::Identity();
+  map2bl.block<3, 3>(0, 0) = R.transpose();
+  map2bl.block<3, 1>(0, 3) = -R.transpose() * t;
+
+  return {bl2map, map2bl};
+}
 
 VadNode::VadNode(const rclcpp::NodeOptions & options) 
   : Node("vad_node", options), 
@@ -391,10 +430,11 @@ std::optional<VadOutputTopicData> VadNode::execute_inference(const VadInputTopic
   // VadModelで推論実行
   const auto vad_output = vad_model_ptr_->infer(vad_input);
 
+  const auto [base2map_transform, map2base_transform] = get_transform_matrix(*current_frame_.kinematic_state);
   // VadInterfaceを通じてROS型に変換
   if (vad_output.has_value()) {
     const auto vad_output_topic_data = vad_interface_ptr_->convert_output(
-      *vad_output, this->now(), trajectory_timestep_);
+      *vad_output, this->now(), trajectory_timestep_, base2map_transform);
 
     // Update prev_can_bus for next frame
     prev_can_bus_ = vad_input.can_bus_;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -81,7 +81,9 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       declare_parameter<std::vector<int64_t>>("interface_params.autoware_to_vad_camera_mapping")
     ),
     tf_buffer_(this->get_clock()),
+    num_cameras_(declare_parameter<int32_t>("node_params.num_cameras")),
     trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0)),
+    current_frame_(num_cameras_),
     frame_started_(false)
 {
   // Initialize prev_can_bus from parameters
@@ -109,12 +111,12 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   auto reliable_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable);
 
   // Subscribers for each camera
-  camera_image_subs_.resize(6);
-  std::vector<bool> use_raw_cameras = this->declare_parameter<std::vector<bool>>("node_params.use_raw", std::vector<bool>(6, false));
+  camera_image_subs_.resize(num_cameras_);
+  std::vector<bool> use_raw_cameras = this->declare_parameter<std::vector<bool>>("node_params.use_raw", std::vector<bool>(num_cameras_, false));
   auto resolve_topic_name = [this](const std::string & query) {
     return this->get_node_topics_interface()->resolve_topic_name(query);
   };
-  for (int32_t i = 0; i < 6; ++i) {
+  for (int32_t i = 0; i < num_cameras_; ++i) {
     const auto transport = use_raw_cameras[i] ? "raw" : "compressed";
     auto callback =
         [this, i](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
@@ -131,8 +133,8 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   }
 
   // Camera info subscribers
-  camera_info_subs_.resize(6);
-  for (int32_t i = 0; i < 6; ++i) {
+  camera_info_subs_.resize(num_cameras_);
+  for (int32_t i = 0; i < num_cameras_; ++i) {
     auto callback =
         [this, i](const sensor_msgs::msg::CameraInfo::SharedPtr msg) {
           this->camera_info_callback(msg, i);
@@ -164,10 +166,6 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   // Load VadConfig
   load_vad_config();
 
-  // Initialize current frame structure
-  current_frame_.images.resize(6);
-  current_frame_.camera_infos.resize(6);
-
   // Initialize VAD model on first complete frame
   if (!vad_model_ptr_) {
     RCLCPP_INFO(this->get_logger(), "Initializing VAD model with first complete frame");
@@ -188,8 +186,8 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
 void VadNode::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id)
 {
   // Validate camera_id
-  if (camera_id >= 6) {
-    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-5", camera_id);
+  if (static_cast<int32_t>(camera_id) >= num_cameras_) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-%d", camera_id, num_cameras_ - 1);
     return;
   }
 
@@ -214,8 +212,8 @@ void VadNode::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, 
 void VadNode::camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id)
 {
   // Validate camera_id
-  if (camera_id >= 6) {
-    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-5", camera_id);
+  if (static_cast<int32_t>(camera_id) >= num_cameras_) {
+    RCLCPP_ERROR(this->get_logger(), "Invalid camera_id: %zu. Expected 0-%d", camera_id, num_cameras_ - 1);
     return;
   }
 
@@ -313,13 +311,7 @@ void VadNode::check_and_process_frame()
 
 void VadNode::reset_current_frame()
 {
-  current_frame_.images.clear();
-  current_frame_.images.resize(6);
-  current_frame_.camera_infos.clear();
-  current_frame_.camera_infos.resize(6);
-  current_frame_.kinematic_state.reset();
-  current_frame_.imu_raw.reset();
-  current_frame_.tf_static.reset();
+  current_frame_.reset();
   frame_started_ = false;
 }
 
@@ -482,7 +474,7 @@ void VadNode::frame_timeout_callback()
     
     RCLCPP_WARN(this->get_logger(), 
                 "Frame timeout reached. Have %d/%d images, %d/%d camera_infos, kinematic_state: %s, imu_raw: %s, tf_static: %s",
-                valid_images, 6, valid_camera_infos, 6,
+                valid_images, num_cameras_, valid_camera_infos, num_cameras_,
                 current_frame_.kinematic_state ? "yes" : "no",
                 current_frame_.imu_raw ? "yes" : "no",
                 current_frame_.tf_static ? "yes" : "no");

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -64,6 +64,10 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
           "~/output/objects",
           rclcpp::QoS(1));
 
+  // Create QoS profiles for sensor data (best effort for compatibility with typical sensor topics)
+  auto sensor_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::BestEffort);
+  auto reliable_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable);
+
   // Subscribers for each camera
   camera_image_subs_.resize(6);
   for (int32_t i = 0; i < 6; ++i) {
@@ -75,7 +79,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
     camera_image_subs_[i] =
         this->create_subscription<sensor_msgs::msg::CompressedImage>(
             "~/input/image" + std::to_string(i),
-            rclcpp::QoS(1), callback);
+            sensor_qos, callback);
   }
 
   // Camera info subscribers
@@ -89,22 +93,24 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
     camera_info_subs_[i] =
         this->create_subscription<sensor_msgs::msg::CameraInfo>(
             "~/input/camera_info" + std::to_string(i),
-            rclcpp::QoS(1), callback);
+            sensor_qos, callback);
   }
 
-  // Odometry subscriber
+  // Odometry subscriber (kinematic state is usually reliable)
   odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-      "/localization/kinematic_state", rclcpp::QoS(1),
+      "/localization/kinematic_state", reliable_qos,
       std::bind(&VadNode::odometry_callback, this, std::placeholders::_1));
 
-  // IMU subscriber
+  // IMU subscriber (sensor data typically uses best effort)
   imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "/sensing/imu/tamagawa/imu_raw", rclcpp::QoS(1),
+      "/sensing/imu/tamagawa/imu_raw", sensor_qos,
       std::bind(&VadNode::imu_callback, this, std::placeholders::_1));
 
-  // TF static subscriber
+  // TF static subscriber (transient local for persistence)
+  auto tf_static_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable)
+                                     .durability(rclcpp::DurabilityPolicy::TransientLocal);
   tf_static_sub_ = this->create_subscription<tf2_msgs::msg::TFMessage>(
-      "/tf_static", rclcpp::QoS(1),
+      "/tf_static", tf_static_qos,
       std::bind(&VadNode::tf_static_callback, this, std::placeholders::_1));
 
   // Load VadConfig

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -123,7 +123,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       std::bind(&VadNode::tf_static_callback, this, std::placeholders::_1));
 
   // Load VadConfig
-  loadVadConfig();
+  load_vad_config();
 
   // Initialize current frame structure
   current_frame_.images.resize(6);
@@ -132,7 +132,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   // Initialize VAD model on first complete frame
   if (!vad_model_ptr_) {
     RCLCPP_INFO(this->get_logger(), "Initializing VAD model with first complete frame");
-    initializeVadModel();
+    initialize_vad_model();
   }
 
   // Initialize timeout timer
@@ -284,7 +284,7 @@ void VadNode::reset_current_frame()
   frame_started_ = false;
 }
 
-void VadNode::initializeVadModel()
+void VadNode::initialize_vad_model()
 {
   // Initialize VAD interface and model
   auto tf_buffer_shared = std::shared_ptr<tf2_ros::Buffer>(&tf_buffer_, [](tf2_ros::Buffer*){});
@@ -297,7 +297,7 @@ void VadNode::initializeVadModel()
   RCLCPP_INFO(this->get_logger(), "VAD model and interface initialized successfully");
 }
 
-void VadNode::loadVadConfig()
+void VadNode::load_vad_config()
 {
   // Load VAD config parameters
   vad_config_.plugins_path =
@@ -306,10 +306,10 @@ void VadNode::loadVadConfig()
       this->declare_parameter<int>("model_params.warm_up_num", 20);
 
   // Load network configurations
-  loadNetConfigs();
+  load_net_configs();
 }
 
-void VadNode::loadNetConfigs()
+void VadNode::load_net_configs()
 {
   // Load network configurations
   
@@ -365,13 +365,13 @@ void VadNode::loadNetConfigs()
   vad_config_.nets_config.push_back(head_no_prev_config);
 }
 
-void VadNode::publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)
+void VadNode::publish_trajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)
 {
   auto candidate_trajectories_msg = std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories);
   candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
 }
 
-void VadNode::publishTrajectory(const autoware_planning_msgs::msg::Trajectory & trajectory)
+void VadNode::publish_trajectory(const autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   auto trajectory_msg = std::make_unique<autoware_planning_msgs::msg::Trajectory>(trajectory);
   trajectory_publisher_->publish(std::move(trajectory_msg));
@@ -415,10 +415,10 @@ void VadNode::publish(const VadInputTopicData & vad_topic_data)
   // 結果をパブリッシュ
   if (vad_output_topic_data.has_value()) {
     // Publish individual trajectory using the dedicated method
-    publishTrajectory(vad_output_topic_data.value().trajectory);
+    publish_trajectory(vad_output_topic_data.value().trajectory);
 
     // Publish candidate trajectories
-    publishTrajectories(vad_output_topic_data.value().candidate_trajectories);
+    publish_trajectories(vad_output_topic_data.value().candidate_trajectories);
 
     RCLCPP_DEBUG(this->get_logger(), "Published trajectories and candidate trajectories");
   } else {

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -433,11 +433,10 @@ void VadNode::publishTrajectory(const std::vector<float> &planning)
   trajectory_publisher_->publish(std::move(trajectory_msg));
 }
 
-void VadNode::publishTrajectories(const std::map<int32_t, std::vector<float>> &trajectories_map)
+autoware_internal_planning_msgs::msg::CandidateTrajectories VadNode::convert_candidate_trajectories(const std::map<int32_t, std::vector<float>> &trajectories_map)
 {
   // CandidateTrajectories メッセージを作成
-  auto candidate_trajectories_msg =
-      std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
+  autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories_msg;
 
   // 各コマンドの軌道をCandidateTrajectoryとして追加
   for (const auto& [command_idx, trajectory] : trajectories_map) {
@@ -494,15 +493,21 @@ void VadNode::publishTrajectories(const std::map<int32_t, std::vector<float>> &t
       candidate_trajectory.points.push_back(point);
     }
 
-    candidate_trajectories_msg->candidate_trajectories.push_back(candidate_trajectory);
+    candidate_trajectories_msg.candidate_trajectories.push_back(candidate_trajectory);
 
     // 各コマンドのGeneratorInfoを追加
     autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
     generator_info.generator_id = autoware_utils_uuid::generate_uuid();
     generator_info.generator_name.data = "autoware_tensorrt_vad_cmd_" + std::to_string(command_idx);
-    candidate_trajectories_msg->generator_info.push_back(generator_info);
+    candidate_trajectories_msg.generator_info.push_back(generator_info);
   }
 
+  return candidate_trajectories_msg;
+}
+
+void VadNode::publishTrajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)
+{
+  auto candidate_trajectories_msg = std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories);
   candidate_trajectories_publisher_->publish(std::move(candidate_trajectories_msg));
 }
 
@@ -531,12 +536,13 @@ std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories> VadNo
         publishTrajectory(vad_output->predicted_trajectory_);
       }
 
-      // Publish candidate trajectories if available
+      // Convert candidate trajectories if available
       if (!vad_output->predicted_trajectories_.empty()) {
-        publishTrajectories(vad_output->predicted_trajectories_);
+        auto candidate_trajectories_msg = convert_candidate_trajectories(vad_output->predicted_trajectories_);
+        return std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories_msg);
       }
 
-      // Return a simple success indicator - we already published the data above
+      // Return empty message if no trajectories available
       auto candidate_trajectories_msg = autoware_internal_planning_msgs::msg::CandidateTrajectories();
       return std::optional<autoware_internal_planning_msgs::msg::CandidateTrajectories>(candidate_trajectories_msg);
     }
@@ -555,7 +561,7 @@ void VadNode::publish(const VadInputTopicData & vad_topic_data)
 
     // 結果をパブリッシュ
     if (candidate_trajectories_msg.has_value()) {
-      // We already published in execute_inference, just log success
+      publishTrajectories(candidate_trajectories_msg.value());
       RCLCPP_DEBUG(this->get_logger(), "Published candidate trajectories");
     } else {
       RCLCPP_WARN(this->get_logger(), "No valid trajectories to publish");

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -45,12 +45,12 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
     trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0)),
     frame_started_(false)
 {
-  // Initialize prev_can_bus from parameters like in main.cpp
+  // Initialize prev_can_bus from parameters
   std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
   prev_can_bus_.clear();
   for (auto v : default_can_bus) prev_can_bus_.push_back(static_cast<float>(v));
 
-  // Publishers like in main.cpp - use output remapping from launch file
+  // Publishers
   trajectory_publisher_ =
       this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
           "~/output/trajectory", rclcpp::QoS(1));
@@ -64,7 +64,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
           "~/output/objects",
           rclcpp::QoS(1));
 
-  // Subscribers for each camera like in main.cpp
+  // Subscribers for each camera
   camera_image_subs_.resize(6);
   for (int32_t i = 0; i < 6; ++i) {
     auto callback =
@@ -92,12 +92,12 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
             rclcpp::QoS(1), callback);
   }
 
-  // Odometry subscriber like in extract_vad_topic_data_from_rosbag
+  // Odometry subscriber
   odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
       "/localization/kinematic_state", rclcpp::QoS(1),
       std::bind(&VadNode::odometry_callback, this, std::placeholders::_1));
 
-  // IMU subscriber like in extract_vad_topic_data_from_rosbag
+  // IMU subscriber
   imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
       "/sensing/imu/tamagawa/imu_raw", rclcpp::QoS(1),
       std::bind(&VadNode::imu_callback, this, std::placeholders::_1));
@@ -107,7 +107,7 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       "/tf_static", rclcpp::QoS(1),
       std::bind(&VadNode::tf_static_callback, this, std::placeholders::_1));
 
-  // Load VadConfig like in main.cpp
+  // Load VadConfig
   loadVadConfig();
 
   // Initialize current frame structure
@@ -237,7 +237,7 @@ void VadNode::tf_static_callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr 
 
   current_frame_.tf_static = msg;
 
-  // Register transforms in tf_buffer like in main.cpp
+  // Register transforms in tf_buffer
   for (const auto &transform : msg->transforms) {
     tf_buffer_.setTransform(transform, "default_authority", true);
   }
@@ -296,11 +296,11 @@ void VadNode::reset_current_frame()
 void VadNode::initializeVadModel()
 {
   try {
-    // Initialize VAD interface and model like in main.cpp
+    // Initialize VAD interface and model
     auto tf_buffer_shared = std::shared_ptr<tf2_ros::Buffer>(&tf_buffer_, [](tf2_ros::Buffer*){});
     vad_interface_ptr_ = std::make_unique<VadInterface>(vad_interface_config_, tf_buffer_shared);
     
-    // Create RosVadLogger using the logger directly (no shared_from_this needed)
+    // Create RosVadLogger using the logger
     auto ros_logger = std::make_shared<RosVadLogger>(this->get_logger());
     vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_config_, ros_logger);
     
@@ -312,7 +312,7 @@ void VadNode::initializeVadModel()
 
 void VadNode::loadVadConfig()
 {
-  // Load VAD config parameters like in main.cpp
+  // Load VAD config parameters
   vad_config_.plugins_path =
       this->declare_parameter<std::string>("model_params.plugins_path", "");
   vad_config_.warm_up_num =
@@ -324,7 +324,7 @@ void VadNode::loadVadConfig()
 
 void VadNode::loadNetConfigs()
 {
-  // Load network configurations like in main.cpp
+  // Load network configurations
   
   // backbone configuration
   NetConfig backbone_config;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -64,6 +64,8 @@ std::pair<Eigen::Matrix4f, Eigen::Matrix4f> get_transform_matrix(
 
 VadNode::VadNode(const rclcpp::NodeOptions & options) 
   : Node("vad_node", options), 
+    tf_buffer_(this->get_clock()),
+    num_cameras_(declare_parameter<int32_t>("node_params.num_cameras")),
     vad_interface_config_(
       declare_parameter<int32_t>("interface_params.input_image_width"),
       declare_parameter<int32_t>("interface_params.input_image_height"),
@@ -81,8 +83,6 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       declare_parameter<std::vector<double>>("interface_params.vad2base"),
       declare_parameter<std::vector<int64_t>>("interface_params.autoware_to_vad_camera_mapping")
     ),
-    tf_buffer_(this->get_clock()),
-    num_cameras_(declare_parameter<int32_t>("node_params.num_cameras")),
     trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0)),
     current_frame_(num_cameras_),
     frame_started_(false)

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -609,12 +609,3 @@ void VadNode::frame_timeout_callback()
 // Register the component with the ROS2 component system
 // NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
 RCLCPP_COMPONENTS_REGISTER_NODE(autoware::tensorrt_vad::VadNode)
-
-int main(int argc, char ** argv)
-{
-  rclcpp::init(argc, argv);
-  auto node = std::make_shared<autoware::tensorrt_vad::VadNode>(rclcpp::NodeOptions{});
-  rclcpp::spin(node);
-  rclcpp::shutdown();
-  return 0;
-}

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -286,19 +286,15 @@ void VadNode::reset_current_frame()
 
 void VadNode::initializeVadModel()
 {
-  try {
-    // Initialize VAD interface and model
-    auto tf_buffer_shared = std::shared_ptr<tf2_ros::Buffer>(&tf_buffer_, [](tf2_ros::Buffer*){});
-    vad_interface_ptr_ = std::make_unique<VadInterface>(vad_interface_config_, tf_buffer_shared);
-    
-    // Create RosVadLogger using the logger
-    auto ros_logger = std::make_shared<RosVadLogger>(this->get_logger());
-    vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_config_, ros_logger);
-    
-    RCLCPP_INFO(this->get_logger(), "VAD model and interface initialized successfully");
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to initialize VAD model: %s", e.what());
-  }
+  // Initialize VAD interface and model
+  auto tf_buffer_shared = std::shared_ptr<tf2_ros::Buffer>(&tf_buffer_, [](tf2_ros::Buffer*){});
+  vad_interface_ptr_ = std::make_unique<VadInterface>(vad_interface_config_, tf_buffer_shared);
+
+  // Create RosVadLogger using the logger
+  auto ros_logger = std::make_shared<RosVadLogger>(this->get_logger());
+  vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_config_, ros_logger);
+
+  RCLCPP_INFO(this->get_logger(), "VAD model and interface initialized successfully");
 }
 
 void VadNode::loadVadConfig()

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -120,6 +120,12 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
   current_frame_.images.resize(6);
   current_frame_.camera_infos.resize(6);
 
+  // Initialize VAD model on first complete frame
+  if (!vad_model_ptr_) {
+    RCLCPP_INFO(this->get_logger(), "Initializing VAD model with first complete frame");
+    initializeVadModel();
+  }
+
   // Initialize timeout timer
   frame_timeout_timer_ = this->create_wall_timer(
     FRAME_TIMEOUT,
@@ -260,17 +266,9 @@ void VadNode::check_and_process_frame()
     
     // Cancel timeout timer since frame is complete
     frame_timeout_timer_->cancel();
-    
-    // Initialize VAD model on first complete frame
-    if (!vad_model_ptr_) {
-      RCLCPP_INFO(this->get_logger(), "Initializing VAD model with first complete frame");
-      initializeVadModel();
-    }
 
-    if (vad_model_ptr_) {
-      // Execute inference and publish results
-      publish(current_frame_);
-    }
+    // Execute inference and publish results
+    publish(current_frame_);
 
     // Reset frame for next data collection
     reset_current_frame();

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -146,12 +146,12 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
 
   // Odometry subscriber (kinematic state is usually reliable)
   odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-      "/localization/kinematic_state", reliable_qos,
+      "~/input/kinematic_state", reliable_qos,
       std::bind(&VadNode::odometry_callback, this, std::placeholders::_1));
 
   // IMU subscriber (sensor data typically uses best effort)
   imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "/sensing/imu/tamagawa/imu_raw", sensor_qos,
+      "~/input/imu_raw", sensor_qos,
       std::bind(&VadNode::imu_callback, this, std::placeholders::_1));
 
   // TF static subscriber (transient local for persistence)

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_interface.cpp
@@ -73,6 +73,7 @@ TEST(VadLidar2ImgTest, DummyInputOutput)
     double default_patch_angle = -1.0353195667266846;
     int32_t default_command = 0;
     std::vector<double> default_shift = {0.0, 0.0};
+    std::vector<double> default_can_bus = {-42274.0312, 89140.4531, 6.92498255, -0.00156072155, -0.0132345976, -0.475291312, 0.879727542, 0.158691406, -2.24609375, -9.72595215, 0.0, 0.0, 0.00481297961, 0.0, 2.15303349, 0.0, 5.19237747, 303.230896};
     std::vector<double> image_normalization_param_mean = {103.530, 116.280, 123.675};
     std::vector<double> image_normalization_param_std = {1.0, 1.0, 1.0};
     std::vector<double> vad2base = {
@@ -96,6 +97,7 @@ TEST(VadLidar2ImgTest, DummyInputOutput)
         default_patch_angle,
         default_command,
         default_shift,
+        default_can_bus,
         image_normalization_param_mean,
         image_normalization_param_std,
         vad2base,

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -200,7 +200,7 @@ public:
     }
 
     // VadConfigを読み込み
-    loadVadConfig();
+    load_vad_config();
 
     RCLCPP_INFO(this->get_logger(), "VAD Node has been initialized");
   }
@@ -210,7 +210,7 @@ public:
     return vad_config_;
   }
 
-  void publishTrajectory(const std::vector<float> &planning) {
+  void publish_trajectory(const std::vector<float> &planning) {
     auto trajectory_msg =
         std::make_unique<autoware_planning_msgs::msg::Trajectory>();
 
@@ -219,7 +219,7 @@ public:
     initial_point.pose.position.x = 0.0;
     initial_point.pose.position.y = 0.0;
     initial_point.pose.position.z = 0.0;
-    initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+    initial_point.pose.orientation = create_quaternion_from_yaw(0.0);
     initial_point.longitudinal_velocity_mps = 0.0;
     initial_point.lateral_velocity_mps = 0.0;
     initial_point.acceleration_mps2 = 0.0;
@@ -241,7 +241,7 @@ public:
         float aw_dx = ns_dy;  // Autowareの座標系に変換
         float aw_dy = -ns_dx; // Autowareの座標系に変換
         float yaw = std::atan2(aw_dy, aw_dx);
-        point.pose.orientation = createQuaternionFromYaw(yaw);
+        point.pose.orientation = create_quaternion_from_yaw(yaw);
       }
 
       point.longitudinal_velocity_mps = 0.0;
@@ -264,7 +264,7 @@ public:
     trajectory_publisher_->publish(std::move(trajectory_msg));
   }
 
-  void publishTrajectories(const std::map<int32_t, std::vector<float>> &trajectories_map) {
+  void publish_trajectories(const std::map<int32_t, std::vector<float>> &trajectories_map) {
     // CandidateTrajectories メッセージを作成
     auto candidate_trajectories_msg =
         std::make_unique<autoware_internal_planning_msgs::msg::CandidateTrajectories>();
@@ -285,7 +285,7 @@ public:
       initial_point.pose.position.x = 0.0;
       initial_point.pose.position.y = 0.0;
       initial_point.pose.position.z = 0.0;
-      initial_point.pose.orientation = createQuaternionFromYaw(0.0);
+      initial_point.pose.orientation = create_quaternion_from_yaw(0.0);
       initial_point.longitudinal_velocity_mps = 0.0;
       initial_point.lateral_velocity_mps = 0.0;
       initial_point.acceleration_mps2 = 0.0;
@@ -307,7 +307,7 @@ public:
           float aw_dx = ns_dy;  // Autowareの座標系に変換
           float aw_dy = -ns_dx; // Autowareの座標系に変換
           float yaw = std::atan2(aw_dy, aw_dx);
-          point.pose.orientation = createQuaternionFromYaw(yaw);
+          point.pose.orientation = create_quaternion_from_yaw(yaw);
         }
 
         point.longitudinal_velocity_mps = 0.0;
@@ -352,7 +352,7 @@ public:
       object.kinematics.pose_with_covariance.pose.position.z = det[2];
 
       object.kinematics.pose_with_covariance.pose.orientation =
-          createQuaternionFromYaw(det[6]);
+          create_quaternion_from_yaw(det[6]);
 
       object.shape.dimensions.x = det[3]; // width
       object.shape.dimensions.y = det[4]; // length
@@ -402,7 +402,7 @@ private:
     return node_options;
   }
 
-  void loadVadConfig() {
+  void load_vad_config() {
     // このノード自体からパラメータを読み込み
     vad_config_.plugins_path =
         this->declare_parameter<std::string>("model_params.plugins_path", "");
@@ -410,10 +410,10 @@ private:
         this->declare_parameter<int>("model_params.warm_up_num", 20);
 
     // ネットワーク設定の読み込み
-    loadNetConfigs();
+    load_net_configs();
   }
 
-  void loadNetConfigs() {
+  void load_net_configs() {
     // 階層構造でネットワーク設定を読み込み
 
     // backbone設定
@@ -477,7 +477,7 @@ private:
                  camera_index);
   }
 
-  geometry_msgs::msg::Quaternion createQuaternionFromYaw(double yaw) {
+  geometry_msgs::msg::Quaternion create_quaternion_from_yaw(double yaw) {
     geometry_msgs::msg::Quaternion q;
     q.x = 0.0;
     q.y = 0.0;
@@ -798,10 +798,10 @@ int main(int argc, char **argv) {
 
     // pred -> frame.planning
     frame.planning = vad_output_data.predicted_trajectory_;
-    node->publishTrajectory(frame.planning);
+    node->publish_trajectory(frame.planning);
     
     // publish all trajectories as CandidateTrajectories
-    node->publishTrajectories(vad_output_data.predicted_trajectories_);
+    node->publish_trajectories(vad_output_data.predicted_trajectories_);
     
     printf("publish trajectory");
     rclcpp::spin_some(node);

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -144,7 +144,6 @@ convert_normalized_to_rgb(const std::vector<float> &normalized_data) {
 class VADNode : public rclcpp::Node {
 public:
   autoware::tensorrt_vad::VadInterfaceConfig vad_interface_config_;
-  std::vector<float> prev_can_bus_;
 
   VADNode(const std::vector<std::string> &yaml_config_paths)
       : Node("vad_node", createNodeOptions(yaml_config_paths)),
@@ -159,6 +158,7 @@ public:
           declare_parameter<double>("interface_params.default_patch_angle"),
           declare_parameter<int32_t>("model_params.default_command"),
           declare_parameter<std::vector<double>>("interface_params.default_shift"),
+          declare_parameter<std::vector<double>>("interface_params.default_can_bus"),
           declare_parameter<std::vector<double>>("interface_params.image_normalization_param_mean"),
           declare_parameter<std::vector<double>>("interface_params.image_normalization_param_std"),
           declare_parameter<std::vector<double>>("interface_params.vad2base"),
@@ -166,11 +166,6 @@ public:
         ),
         trajectory_timestep_(declare_parameter<double>("interface_params.trajectory_timestep", 1.0))
   {
-
-    std::vector<double> default_can_bus = this->declare_parameter<std::vector<double>>("interface_params.default_can_bus");
-    // default_can_bus: copy and convert
-    prev_can_bus_.clear();
-    for (auto v : default_can_bus) prev_can_bus_.push_back(static_cast<float>(v));
     // Publishers
     trajectory_publisher_ =
         this->create_publisher<autoware_planning_msgs::msg::Trajectory>(
@@ -544,7 +539,7 @@ extract_vad_topic_data_from_rosbag(const std::string &bag_path, std::shared_ptr<
     rosbag2_cpp::readers::SequentialReader reader;
     reader.open(storage_options, converter_options);
 
-    autoware::tensorrt_vad::VadInputTopicData current_frame;
+    autoware::tensorrt_vad::VadInputTopicData current_frame(6);
     bool frame_started = false;
 
     while (reader.has_next()) {
@@ -748,17 +743,11 @@ int main(int argc, char **argv) {
 
   
   // フレームごとに処理
-  std::vector<float> prev_can_bus = node->prev_can_bus_;
   for (int32_t frame_id = 1; frame_id <= vad_topic_data_list.size(); frame_id++) {
     std::string frame_dir = data_dir + std::to_string(frame_id) + "/";
 
-    // VadInterfaceを使用してVadInputTopicDataをVadInputDataに変換（古いprev_can_busを使用）
-    auto vad_input_data = vad_interface.convert_input(
-        vad_topic_data_list[frame_id - 1],
-        prev_can_bus);
-
-    // 前フレームのcan_busデータを更新（次のフレーム用）
-    prev_can_bus = vad_input_data.can_bus_;
+    // VadInterfaceを使用してVadInputTopicDataをVadInputDataに変換
+    auto vad_input_data = vad_interface.convert_input(vad_topic_data_list[frame_id - 1]);
 
     // VadModelのinfer関数を使用
     auto inference_result = vad_model.infer(vad_input_data);

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -680,7 +680,7 @@ extract_vad_topic_data_from_rosbag(const std::string &bag_path, std::shared_ptr<
         vad_topic_data_list.push_back(current_frame);
 
         // 次のフレームの準備
-        current_frame = autoware::tensorrt_vad::VadInputTopicData();
+        current_frame = autoware::tensorrt_vad::VadInputTopicData(6);
         frame_started = false;
       }
     }

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -37,6 +37,8 @@
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb/stb_image_resize.h>
 
+#include <opencv2/opencv.hpp>
+
 #include <Eigen/Dense>
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
@@ -563,21 +565,25 @@ extract_vad_topic_data_from_rosbag(const std::string &bag_path, std::shared_ptr<
           // CompressedImageをImageに変換
           auto image_msg = std::make_shared<sensor_msgs::msg::Image>();
           image_msg->header = msg->header;
-          image_msg->height = msg->format.find("height=") != std::string::npos
-                                  ? std::stoi(msg->format.substr(
-                                        msg->format.find("height=") + 7,
-                                        msg->format.find(";") -
-                                            msg->format.find("height=") - 7))
-                                  : 0;
-          image_msg->width =
-              msg->format.find("width=") != std::string::npos
-                  ? std::stoi(msg->format.substr(
-                        msg->format.find("width=") + 6,
-                        msg->format.find(";") - msg->format.find("width=") - 6))
-                  : 0;
+          
+          // OpenCVで圧縮画像をデコード
+          cv::Mat bgr_img = cv::imdecode(cv::Mat(msg->data), cv::IMREAD_COLOR);
+          if (bgr_img.empty()) {
+            std::cerr << "Failed to decode compressed image for camera " 
+                      << autoware_idx << std::endl;
+            continue;
+          }
+          
+          // デコードした画像からImage メッセージを作成
+          image_msg->height = bgr_img.rows;
+          image_msg->width = bgr_img.cols;
           image_msg->encoding = "bgr8";
-          image_msg->data = msg->data;
-          image_msg->step = image_msg->width * 3;
+          image_msg->step = bgr_img.cols * 3;
+          
+          // ピクセルデータをコピー
+          size_t data_size = bgr_img.rows * bgr_img.cols * 3;
+          image_msg->data.resize(data_size);
+          std::memcpy(image_msg->data.data(), bgr_img.data, data_size);
 
           if (!frame_started) {
             current_frame.stamp = msg->header.stamp;


### PR DESCRIPTION
# Description

- Add VAD ROS Node


# How this PR is tested

<details>
<summary>log of test in vad-trt</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/demo$ cd ../demo;../b
uild/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1752928871.807010937] [vad_node]: VAD Node has been initialized
[INFO 1752928871.810836282] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1752928871.810874173] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1752928871.893793789] [vad_node]: -> engine: head_no_prev
[INFO 1752928871.893839141] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1752928872.122849406] [vad_node]: warm_up=20
[INFO] n_frames=30
[INFO 1752928872.426418464] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/awsim_bag.ns-0.4-0.9_0.db3' for READ_ONLY.
[INFO 1752928873.152008307] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1752928873.152057894] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=0 finished
publish trajectory[INFO] 2, cmd=0 finished
publish trajectory[INFO] 3, cmd=0 finished
publish trajectory[INFO] 4, cmd=0 finished
publish trajectory[INFO] 5, cmd=0 finished
publish trajectory[INFO] 6, cmd=0 finished
publish trajectory[INFO] 7, cmd=0 finished
publish trajectory[INFO] 8, cmd=0 finished
publish trajectory[INFO] 9, cmd=0 finished
publish trajectory[INFO] 10, cmd=0 finished
publish trajectory[INFO] 11, cmd=0 finished
publish trajectory[INFO] 12, cmd=0 finished
publish trajectorydet: 7.9721, 15.3558, 0.320238, 2.19083, 0.495618, 1.09677, -0.00797124, 6.13806e-06, 7.31531e-05, 5, 0.355344
[INFO] 13, cmd=0 finished
publish trajectory[INFO] 14, cmd=0 finished
publish trajectory[INFO] 15, cmd=0 finished
publish trajectory[INFO] 16, cmd=0 finished
publish trajectory[INFO] 17, cmd=0 finished
publish trajectory[INFO] 18, cmd=0 finished
publish trajectory[INFO] 19, cmd=0 finished
publish trajectory[INFO] 20, cmd=0 finished
publish trajectory[INFO] 21, cmd=0 finished
publish trajectory[INFO] 22, cmd=0 finished
publish trajectory[INFO] 23, cmd=0 finished
publish trajectory[INFO] 24, cmd=0 finished
publish trajectory[INFO] 25, cmd=0 finished
publish trajectory[INFO] 26, cmd=0 finished
publish trajectory[INFO] 27, cmd=0 finished
publish trajectory[INFO] 28, cmd=0 finished
publish trajectory[INFO] 29, cmd=0 finished
```

</details>

<details>
<summary>log of test in autoware_tensorrt_vad</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ colcon build --packages-select autoware_tensorrt_vad
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [0.36s]                    

Summary: 1 package finished [0.56s]

autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_integration 
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (645 ms)
[----------] 1 test from VadIntegrationTest (645 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b9380 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b9270 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b9270 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b9270 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b9360 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (388 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8fa0 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8e90 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8e90 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8e90 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8f80 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8e30 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffd834b8e30 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (801 ms)
[----------] 2 tests from VadInferIntegrationTest (1189 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1834 ms total)
[  PASSED  ] 3 tests.

autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```

</details>