### PR TITLE
feat(autoware_tensorrt_vad): use /localization/acceleration instead of imu

### DIFF
--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -30,6 +30,7 @@
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -65,8 +66,8 @@ struct VadInputTopicData
   // 車両の運動状態データ（/localization/kinematic_state などから）
   nav_msgs::msg::Odometry::ConstSharedPtr kinematic_state;
 
-  // IMUデータ（/sensing/imu/tamagawa/imu_raw などから）
-  sensor_msgs::msg::Imu::ConstSharedPtr imu_raw;
+  // 加速度データ（/localization/acceleration から）
+  geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr acceleration;
 
 private:
   int32_t num_cameras_;
@@ -91,7 +92,7 @@ public:
     
     return tf_static != nullptr && 
            kinematic_state != nullptr && 
-           imu_raw != nullptr;
+           acceleration != nullptr;
   }
 
   // フレームをリセットする
@@ -101,7 +102,7 @@ public:
     camera_infos.clear();
     camera_infos.resize(num_cameras_);
     kinematic_state.reset();
-    imu_raw.reset();
+    acceleration.reset();
     tf_static.reset();
   }
 };
@@ -156,7 +157,7 @@ public:
 
   CanBusData process_can_bus(
     const nav_msgs::msg::Odometry::ConstSharedPtr & kinematic_state,
-    const sensor_msgs::msg::Imu::ConstSharedPtr & imu_raw,
+    const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr & acceleration,
     const std::vector<float> & prev_can_bus) const;
 
   ShiftData process_shift(

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -35,6 +35,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 
@@ -73,7 +74,7 @@ private:
   void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg, std::size_t camera_id);
   void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg, std::size_t camera_id);
   void odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
-  void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg);
+  void acceleration_callback(const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg);
   void tf_static_callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg);
 
   // Helper functions for data synchronization
@@ -92,9 +93,9 @@ private:
   std::vector<image_transport::Subscriber> camera_image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;
 
-  // Subscribers for odometry and IMU data
+  // Subscribers for odometry and acceleration data
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
-  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr acceleration_sub_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_static_sub_;
 
   // VAD model

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/launch/vad.launch.xml
@@ -19,7 +19,7 @@
   <arg name="image5" default="/sensing/camera/camera5/image_rect_color"/>
 
   <arg name="kinematic_state" default="/localization/kinematic_state"/>
-  <arg name="imu_raw" default="/sensing/imu/tamagawa/imu_raw"/>
+  <arg name="acceleration" default="/localization/acceleration"/>
 
   <arg name="output/objects" default="perception/object_recognition/detection/vad/objects"/>
   <arg name="output/trajectory" default="planning/vad/trajectory"/>
@@ -47,7 +47,7 @@
     <remap from="~/input/image5" to="$(var image5)"/>
     
     <remap from="~/input/kinematic_state" to="$(var kinematic_state)"/>
-    <remap from="~/input/imu_raw" to="$(var imu_raw)"/>
+    <remap from="~/input/acceleration" to="$(var acceleration)"/>
   </node>
 
   <!-- Rviz for individual node testing-->

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -47,7 +47,7 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
   // Process can_bus and shift data
   vad_input_data.can_bus_ = process_can_bus(
     vad_input_topic_data.kinematic_state,
-    vad_input_topic_data.imu_raw,
+    vad_input_topic_data.acceleration,
     prev_can_bus_
   );
   vad_input_data.shift_ = process_shift(vad_input_data.can_bus_, prev_can_bus_);
@@ -281,7 +281,7 @@ CameraImagesData VadInterface::process_image(
 
 CanBusData VadInterface::process_can_bus(
   const nav_msgs::msg::Odometry::ConstSharedPtr & kinematic_state,
-  const sensor_msgs::msg::Imu::ConstSharedPtr & imu_raw,
+  const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr & acceleration,
   const std::vector<float> & prev_can_bus) const
 {
   CanBusData can_bus(18, 0.0f);
@@ -314,9 +314,9 @@ CanBusData VadInterface::process_can_bus(
 
   // Apply Autoware to VAD base_link coordinate transformation to acceleration
   auto [vad_ax, vad_ay, vad_az] =
-      aw2vad_xyz(imu_raw->linear_acceleration.x,
-                imu_raw->linear_acceleration.y,
-                imu_raw->linear_acceleration.z);
+      aw2vad_xyz(acceleration->accel.accel.linear.x,
+                acceleration->accel.accel.linear.y,
+                acceleration->accel.accel.linear.z);
 
   // acceleration (7:10)
   can_bus[7] = vad_ax;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -19,6 +19,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 
 namespace autoware::tensorrt_vad
 {
@@ -117,10 +118,10 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       "~/input/kinematic_state", reliable_qos,
       std::bind(&VadNode::odometry_callback, this, std::placeholders::_1));
 
-  // IMU subscriber (sensor data typically uses best effort)
-  imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "~/input/imu_raw", sensor_qos,
-      std::bind(&VadNode::imu_callback, this, std::placeholders::_1));
+  // Acceleration subscriber (sensor data typically uses best effort)
+  acceleration_sub_ = this->create_subscription<geometry_msgs::msg::AccelWithCovarianceStamped>(
+      "~/input/acceleration", sensor_qos,
+      std::bind(&VadNode::acceleration_callback, this, std::placeholders::_1));
 
   // TF static subscriber (transient local for persistence)
   auto tf_static_qos = rclcpp::QoS(1).reliability(rclcpp::ReliabilityPolicy::Reliable)
@@ -217,7 +218,7 @@ void VadNode::odometry_callback(const nav_msgs::msg::Odometry::ConstSharedPtr ms
   RCLCPP_DEBUG(this->get_logger(), "Received odometry data");
 }
 
-void VadNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+void VadNode::acceleration_callback(const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(frame_mutex_);
 
@@ -229,10 +230,10 @@ void VadNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
     frame_timeout_timer_->reset();
   }
 
-  current_frame_.imu_raw = msg;
+  current_frame_.acceleration = msg;
   check_and_process_frame();
 
-  RCLCPP_DEBUG(this->get_logger(), "Received IMU data");
+  RCLCPP_DEBUG(this->get_logger(), "Received acceleration data");
 }
 
 void VadNode::tf_static_callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg)
@@ -435,10 +436,10 @@ void VadNode::frame_timeout_callback()
     }
     
     RCLCPP_WARN(this->get_logger(), 
-                "Frame timeout reached. Have %d/%d images, %d/%d camera_infos, kinematic_state: %s, imu_raw: %s, tf_static: %s",
+                "Frame timeout reached. Have %d/%d images, %d/%d camera_infos, kinematic_state: %s, acceleration: %s, tf_static: %s",
                 valid_images, num_cameras_, valid_camera_infos, num_cameras_,
                 current_frame_.kinematic_state ? "yes" : "no",
-                current_frame_.imu_raw ? "yes" : "no",
+                current_frame_.acceleration ? "yes" : "no",
                 current_frame_.tf_static ? "yes" : "no");
     
     // Reset frame if incomplete

--- a/AV-Solutions/vad-trt/app/demo/rosbag/convert_can_bus_bin_to_rosbag.py
+++ b/AV-Solutions/vad-trt/app/demo/rosbag/convert_can_bus_bin_to_rosbag.py
@@ -7,8 +7,8 @@ from pyquaternion import Quaternion
 from nuscenes.eval.common.utils import quaternion_yaw
 
 # ROS2 関連のインポート
-from sensor_msgs.msg import Imu, CameraInfo
-from geometry_msgs.msg import TransformStamped
+from sensor_msgs.msg import CameraInfo
+from geometry_msgs.msg import TransformStamped, AccelWithCovarianceStamped
 from tf2_msgs.msg import TFMessage
 from builtin_interfaces.msg import Time
 from rclpy.serialization import serialize_message, deserialize_message
@@ -118,67 +118,40 @@ def ns2aw_kinematic_state(kinematic_msg: Odometry) -> Odometry:
     
     return aw_msg
 
-def ns2aw_imu(imu_msg: Imu) -> Imu:
+def ns2aw_acceleration(accel_msg: AccelWithCovarianceStamped) -> AccelWithCovarianceStamped:
     """
-    Convert IMU message from nuScenes to Autoware coordinate system.
+    Convert acceleration message from nuScenes to Autoware coordinate system.
     
     Args:
-        imu_msg: IMU message in nuScenes coordinate system
+        accel_msg: Acceleration message in nuScenes coordinate system
         
     Returns:
-        Imu: Converted message in Autoware coordinate system
+        AccelWithCovarianceStamped: Converted message in Autoware coordinate system
     """
     # Create a deep copy to avoid modifying the original message
-    aw_msg = Imu()
-    aw_msg.header = imu_msg.header
+    aw_msg = AccelWithCovarianceStamped()
+    aw_msg.header = accel_msg.header
     
     # Transform linear accelerations
-    ns_ax = imu_msg.linear_acceleration.x
-    ns_ay = imu_msg.linear_acceleration.y
+    ns_ax = accel_msg.accel.accel.linear.x
+    ns_ay = accel_msg.accel.accel.linear.y
     aw_ax, aw_ay = ns2aw_xy(ns_ax, ns_ay)
     
-    aw_msg.linear_acceleration.x = aw_ax
-    aw_msg.linear_acceleration.y = aw_ay
-    aw_msg.linear_acceleration.z = imu_msg.linear_acceleration.z
+    aw_msg.accel.accel.linear.x = aw_ax
+    aw_msg.accel.accel.linear.y = aw_ay
+    aw_msg.accel.accel.linear.z = accel_msg.accel.accel.linear.z
     
-    # Transform angular velocities
-    ns_wx = imu_msg.angular_velocity.x
-    ns_wy = imu_msg.angular_velocity.y
-    aw_wx, aw_wy = ns2aw_xy(ns_wx, ns_wy)
+    # Transform angular accelerations
+    ns_aax = accel_msg.accel.accel.angular.x
+    ns_aay = accel_msg.accel.accel.angular.y
+    aw_aax, aw_aay = ns2aw_xy(ns_aax, ns_aay)
     
-    aw_msg.angular_velocity.x = aw_wx
-    aw_msg.angular_velocity.y = aw_wy
-    aw_msg.angular_velocity.z = imu_msg.angular_velocity.z  # Yaw rate stays the same
+    aw_msg.accel.accel.angular.x = aw_aax
+    aw_msg.accel.accel.angular.y = aw_aay
+    aw_msg.accel.accel.angular.z = accel_msg.accel.accel.angular.z
     
-    # Transform orientation quaternion if it exists
-    if imu_msg.orientation.x != 0 or imu_msg.orientation.y != 0 or imu_msg.orientation.z != 0 or imu_msg.orientation.w != 0:
-        # Create a Quaternion from the original message
-        q_ns = Quaternion(
-            w=imu_msg.orientation.w,
-            x=imu_msg.orientation.x,
-            y=imu_msg.orientation.y,
-            z=imu_msg.orientation.z
-        )
-        
-        # Create a 90-degree rotation around Z-axis (yaw)
-        q_rotation = Quaternion(axis=[0, 0, 1], angle=np.pi/2)
-        
-        # Apply the rotation
-        q_aw = q_rotation * q_ns
-        
-        # Set the transformed quaternion
-        aw_msg.orientation.x = q_aw.x
-        aw_msg.orientation.y = q_aw.y
-        aw_msg.orientation.z = q_aw.z
-        aw_msg.orientation.w = q_aw.w
-    else:
-        # If orientation is not set, copy the original values
-        aw_msg.orientation = imu_msg.orientation
-    
-    # Copy covariance matrices
-    aw_msg.linear_acceleration_covariance = imu_msg.linear_acceleration_covariance
-    aw_msg.angular_velocity_covariance = imu_msg.angular_velocity_covariance
-    aw_msg.orientation_covariance = imu_msg.orientation_covariance
+    # Copy covariance matrix
+    aw_msg.accel.covariance = accel_msg.accel.covariance
     
     return aw_msg
 
@@ -204,9 +177,9 @@ def calculate_patch_angle_rad(can_bus_rotation_quaternion):
     patch_angle_rad = patch_angle_deg / 180 * np.pi
     return patch_angle_rad
 
-def convert_bin_to_imu(can_bus_data: np.ndarray, timestamp: Time, frame_id: str = "imu_link") -> Imu:
+def convert_bin_to_acceleration(can_bus_data: np.ndarray, timestamp: Time, frame_id: str = "base_link") -> AccelWithCovarianceStamped:
     """
-    CAN busデータから/sensing/imu/tamagawa/imu_rawトピックへの変換
+    CAN busデータから/localization/accelerationトピックへの変換
     
     Args:
         can_bus_data: CANバスデータ
@@ -214,43 +187,34 @@ def convert_bin_to_imu(can_bus_data: np.ndarray, timestamp: Time, frame_id: str 
         frame_id: フレームID
         
     Returns:
-        Imu: 変換されたIMUメッセージ
+        AccelWithCovarianceStamped: 変換された加速度メッセージ
     """
-    # can_bus[7:9] = 加速度(x,y)
-    # can_bus[12] = ego_w（yaw角速度）
+    # can_bus[7:9] = 加速度(x,y,z)
     
     # 加速度の取得（float型に明示的に変換）
     accel_x = float(can_bus_data[7])
     accel_y = float(can_bus_data[8])
     accel_z = float(can_bus_data[9])
     
-    # 角速度の取得（float型に明示的に変換）
-    # TODO(Shin-kyoto): これで良いのかを確認する
-    angular_velocity_z = float(can_bus_data[12])  # Yaw角速度
-    angular_velocity_x = float(can_bus_data[10])
-    angular_velocity_y = float(can_bus_data[11])
-    
-    # IMUメッセージの作成
-    imu_msg = Imu()
-    imu_msg.header.stamp = timestamp
-    imu_msg.header.frame_id = frame_id
+    # AccelWithCovarianceStampedメッセージの作成
+    accel_msg = AccelWithCovarianceStamped()
+    accel_msg.header.stamp = timestamp
+    accel_msg.header.frame_id = frame_id
     
     # 線形加速度の設定
-    imu_msg.linear_acceleration.x = accel_x
-    imu_msg.linear_acceleration.y = accel_y
-    imu_msg.linear_acceleration.z = accel_z
+    accel_msg.accel.accel.linear.x = accel_x
+    accel_msg.accel.accel.linear.y = accel_y
+    accel_msg.accel.accel.linear.z = accel_z
     
-    # 角速度の設定
-    imu_msg.angular_velocity.x = angular_velocity_x
-    imu_msg.angular_velocity.y = angular_velocity_y
-    imu_msg.angular_velocity.z = angular_velocity_z
+    # 角加速度は0に設定（CAN busからは取得できない）
+    accel_msg.accel.accel.angular.x = 0.0
+    accel_msg.accel.accel.angular.y = 0.0
+    accel_msg.accel.accel.angular.z = 0.0
     
     # 共分散行列の設定（不明な場合は-1で埋める）
-    imu_msg.linear_acceleration_covariance = [-1.0] * 9
-    imu_msg.angular_velocity_covariance = [-1.0] * 9
-    imu_msg.orientation_covariance = [-1.0] * 9
+    accel_msg.accel.covariance = [-1.0] * 36
     
-    return imu_msg
+    return accel_msg
 
 def convert_bin_to_kinematic_state(can_bus_data: np.ndarray, timestamp: Time, frame_id: str = "base_link") -> Odometry:
     """
@@ -611,24 +575,32 @@ def main():
     # バッグファイルのオープン
     writer.open(storage_options, converter_options)
     
-    # メタデータの作成と登録
-    camera_topic_types = []
-    for autoware_camera_id in range(6):
-        camera_topic_types.append((f"/sensing/camera/camera{autoware_camera_id}/camera_info", "sensor_msgs/msg/CameraInfo"))
-    topic_types = [
-        ("/sensing/imu/tamagawa/imu_raw", "sensor_msgs/msg/Imu"),
-        ("/localization/kinematic_state", "nav_msgs/msg/Odometry"),
-        ("/tf_static", "tf2_msgs/msg/TFMessage"),
-    ] + camera_topic_types
+    # QoSプロファイルの定義（実際のAutowareのQoSに合わせる）
+    acceleration_qos_profile = "- history: 1\n  depth: 10\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
+    kinematic_state_qos_profile = "- history: 1\n  depth: 1\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
+    tf_static_qos_profile = "- history: 1\n  depth: 1\n  reliability: 1\n  durability: 3\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+    camera_info_qos_profile = "- history: 1\n  depth: 5\n  reliability: 2\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
     
-    # トピックの情報を登録
-    for topic_name, topic_type in topic_types:
-        topic_info = rosbag2_py._storage.TopicMetadata(
+    # メタデータの作成と登録
+    topic_types_with_qos = [
+        ("/localization/acceleration", "geometry_msgs/msg/AccelWithCovarianceStamped", acceleration_qos_profile),
+        ("/localization/kinematic_state", "nav_msgs/msg/Odometry", kinematic_state_qos_profile),
+        ("/tf_static", "tf2_msgs/msg/TFMessage", tf_static_qos_profile),
+    ]
+    
+    # camera_infoトピックを追加
+    for autoware_camera_id in range(6):
+        topic_types_with_qos.append((f"/sensing/camera/camera{autoware_camera_id}/camera_info", "sensor_msgs/msg/CameraInfo", camera_info_qos_profile))
+    
+    # トピックの情報を登録（新しいAPIを使用してQoSを明示的に設定）
+    for topic_name, topic_type, qos_profile in topic_types_with_qos:
+        topic_metadata = rosbag2_py.TopicMetadata(
             name=topic_name,
             type=topic_type,
-            serialization_format="cdr"
+            serialization_format="cdr",
+            offered_qos_profiles=qos_profile
         )
-        writer.create_topic(topic_info)
+        writer.create_topic(topic_metadata)
     
     # 各フレームのデータ処理
     can_bus_data_dict: dict[int, np.ndarray] = {}
@@ -686,10 +658,10 @@ def main():
 
 
         # 各トピックへの変換と書き込み        
-        # 1. IMUの変換と書き込み
-        imu_msg = convert_bin_to_imu(can_bus_data, ros_timestamp)
-        imu_msg = ns2aw_imu(imu_msg)
-        write_to_rosbag(writer, "/sensing/imu/tamagawa/imu_raw", imu_msg, ros_timestamp)
+        # 1. 加速度の変換と書き込み
+        accel_msg = convert_bin_to_acceleration(can_bus_data, ros_timestamp)
+        accel_msg = ns2aw_acceleration(accel_msg)
+        write_to_rosbag(writer, "/localization/acceleration", accel_msg, ros_timestamp)
         
         # 2. 運動学状態の変換と書き込み
         kinematic_msg = convert_bin_to_kinematic_state(can_bus_data, ros_timestamp)
@@ -845,18 +817,18 @@ def reconstruct_can_bus_from_rosbag(bag_file: str, init_time: float, cycle_time_
             reconstructed_data[frame_id]["pitch_rate"] = ns_wy
             reconstructed_data[frame_id]["yaw_rate"] = msg.twist.twist.angular.z  # Yaw rate stays the same
         
-        elif topic_name == "/sensing/imu/tamagawa/imu_raw":
-            msg = deserialize_message(data, Imu)
+        elif topic_name == "/localization/acceleration":
+            msg = deserialize_message(data, AccelWithCovarianceStamped)
             
             # 加速度情報を取得 - AutowareからnuScenesに変換
-            aw_ax = msg.linear_acceleration.x
-            aw_ay = msg.linear_acceleration.y
+            aw_ax = msg.accel.accel.linear.x
+            aw_ay = msg.accel.accel.linear.y
             ns_ax, ns_ay = aw2ns_xy(aw_ax, aw_ay)
             
             reconstructed_data[frame_id]["acceleration"] = [
                 ns_ax,
                 ns_ay,
-                msg.linear_acceleration.z,
+                msg.accel.accel.linear.z,
             ]
     
     # 各フレームのデータを can_bus 形式に変換

--- a/AV-Solutions/vad-trt/app/demo/rosbag/convert_img_can_bus_bin_to_rosbag.py
+++ b/AV-Solutions/vad-trt/app/demo/rosbag/convert_img_can_bus_bin_to_rosbag.py
@@ -6,6 +6,7 @@ import numpy as np
 import cv2
 
 from sensor_msgs.msg import CompressedImage, PointCloud2, PointField
+from geometry_msgs.msg import AccelWithCovarianceStamped
 from std_msgs.msg import Header
 from builtin_interfaces.msg import Time
 import rosbag2_py
@@ -13,8 +14,8 @@ from tf2_msgs.msg import TFMessage
 from rclpy.time import Time as RclpyTime
 import tf2_ros
 from pyquaternion import Quaternion
-from convert_can_bus_bin_to_rosbag import convert_bin_to_imu, convert_bin_to_kinematic_state, write_to_rosbag, convert_bin_to_transform_matrix, create_camera_info_messages
-from convert_can_bus_bin_to_rosbag import ns2aw_kinematic_state, ns2aw_imu, get_base_link_to_vad_base_link_transform_matrix
+from convert_can_bus_bin_to_rosbag import convert_bin_to_acceleration, convert_bin_to_kinematic_state, write_to_rosbag, convert_bin_to_transform_matrix, create_camera_info_messages
+from convert_can_bus_bin_to_rosbag import ns2aw_kinematic_state, ns2aw_acceleration, get_base_link_to_vad_base_link_transform_matrix
 
 def main():
     parser = argparse.ArgumentParser(
@@ -29,7 +30,7 @@ def main():
 
     input_dir = config.get("input_dir", "/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/data/demo_data")
     n_frames = config.get("n_frames", 30)
-    output_file = config.get("output_file", "output_bag.ns-0717")
+    output_file = config.get("output_file", "output_bag.ns-0720")
     topic_template = config.get("topic", "/sensing/camera/camera{i}/image_rect_color/compressed")
     image_format = config.get("image_format", "jpeg")
     init_time = config.get("init_time", 1752738404)
@@ -52,9 +53,9 @@ def main():
     )
     writer.open(storage_options, converter_options)
 
-    # カメラ/IMU/運動学状態/camera_info/tf_static用QoSプロファイル定義（既存バッグと一致）
+    # カメラ/acceleration/運動学状態/camera_info/tf_static用QoSプロファイル定義（実際のAutowareのQoSに合わせる）
     camera_image_qos_profile = "- history: 1\n  depth: 5\n  reliability: 2\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
-    imu_qos_profile = "- history: 1\n  depth: 1000\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
+    acceleration_qos_profile = "- history: 1\n  depth: 10\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
     kinematic_state_qos_profile = "- history: 1\n  depth: 1\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
     camera_info_qos_profile = "- history: 1\n  depth: 5\n  reliability: 2\n  durability: 2\n  deadline:\n    sec: 9223372036\n    nsec: 854775807\n  lifespan:\n    sec: 9223372036\n    nsec: 854775807\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 9223372036\n    nsec: 854775807\n  avoid_ros_namespace_conventions: false"
     tf_static_qos_profile = "- history: 1\n  depth: 1\n  reliability: 1\n  durability: 3\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
@@ -76,13 +77,13 @@ def main():
 
     # CANバス関連トピックの作成
     can_bus_topics = [
-        ("/sensing/imu/tamagawa/imu_raw", "sensor_msgs/msg/Imu"),
+        ("/localization/acceleration", "geometry_msgs/msg/AccelWithCovarianceStamped"),
         ("/localization/kinematic_state", "nav_msgs/msg/Odometry")
     ]
     
     for topic_name, topic_type in can_bus_topics:
-        # IMUと運動学状態は個別QoSを使用
-        qos = imu_qos_profile if topic_name.endswith("imu_raw") else kinematic_state_qos_profile
+        # accelerationと運動学状態は個別QoSを使用
+        qos = acceleration_qos_profile if topic_name.endswith("acceleration") else kinematic_state_qos_profile
         topic_info = rosbag2_py.TopicMetadata(
             name=topic_name,
             type=topic_type,
@@ -96,7 +97,7 @@ def main():
         name="/sensing/lidar/concatenated/pointcloud",
         type="sensor_msgs/msg/PointCloud2",
         serialization_format="cdr",
-        offered_qos_profiles=imu_qos_profile  # 一般的に信頼性重視
+        offered_qos_profiles=acceleration_qos_profile  # 一般的に信頼性重視
     )
     writer.create_topic(lidar_topic_metadata)
 
@@ -152,10 +153,10 @@ def main():
             nanosec=int((base_timestamp - int(base_timestamp)) * 1e9)
         )
 
-        # IMUメッセージの処理 - nuScenes → Autoware 座標変換を適用
-        imu_msg = convert_bin_to_imu(can_bus_data, ros_timestamp)
-        imu_msg = ns2aw_imu(imu_msg)  # 座標変換を適用
-        write_to_rosbag(writer, "/sensing/imu/tamagawa/imu_raw", imu_msg, ros_timestamp)
+        # accelerationメッセージの処理 - nuScenes → Autoware 座標変換を適用
+        accel_msg = convert_bin_to_acceleration(can_bus_data, ros_timestamp)
+        accel_msg = ns2aw_acceleration(accel_msg)  # 座標変換を適用
+        write_to_rosbag(writer, "/localization/acceleration", accel_msg, ros_timestamp)
         
         # 運動学状態メッセージの処理 - nuScenes → Autoware 座標変換を適用
         kinematic_msg = convert_bin_to_kinematic_state(can_bus_data, ros_timestamp)

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -65,7 +65,7 @@
 
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-#include <sensor_msgs/msg/imu.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
@@ -653,11 +653,11 @@ extract_vad_topic_data_from_rosbag(const std::string &bag_path, std::shared_ptr<
         current_frame.kinematic_state = msg;
       }
 
-      // IMUトピックの処理
-      if (bag_message->topic_name == "/sensing/imu/tamagawa/imu_raw") {
-        auto msg = std::make_shared<sensor_msgs::msg::Imu>();
+      // Accelerationトピックの処理
+      if (bag_message->topic_name == "/localization/acceleration") {
+        auto msg = std::make_shared<geometry_msgs::msg::AccelWithCovarianceStamped>();
         rclcpp::SerializedMessage serialized_msg(*bag_message->serialized_data);
-        rclcpp::Serialization<sensor_msgs::msg::Imu>().deserialize_message(
+        rclcpp::Serialization<geometry_msgs::msg::AccelWithCovarianceStamped>().deserialize_message(
             &serialized_msg, msg.get());
 
         if (!frame_started) {
@@ -667,7 +667,7 @@ extract_vad_topic_data_from_rosbag(const std::string &bag_path, std::shared_ptr<
           frame_started = true;
         }
 
-        current_frame.imu_raw = msg;
+        current_frame.acceleration = msg;
       }
 
       // フレームが完成したらリストに追加


### PR DESCRIPTION
# Description

- Use /localization/acceleration instead of imu


# How this PR is tested

<details>
<summary>log of test in autoware_tensorrt_vad</summary>

```sh
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad && colcon build --packages-select autoware_tensorrt_vad --cmake-args -DCMAKE_BUILD_TYPE=Release
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [0.30s]                     

Summary: 1 package finished [0.44s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ colcon test --packages-select autoware_tensorrt_vad --ctes
t-args -R test_vad_integration test_vad_interface
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [2.04s]          

Summary: 1 package finished [2.21s]
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad$ cd ./build/autoware_tensorrt_vad/
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_integration 
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (508 ms)
[----------] 1 test from VadIntegrationTest (508 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3bb0 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3aa0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3aa0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3aa0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3b90 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (403 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f37d0 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f36c0 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f36c0 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f36c0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f37b0 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3660 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff99f3660 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (790 ms)
[----------] 2 tests from VadInferIntegrationTest (1193 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1701 ms total)
[  PASSED  ] 3 tests.
autoware@dpc2308007:~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/build/autoware_tensorrt_vad$ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```

</details>