### PR TITLE
refactor(autoware_tensorrt_vad): rename VadConfig to VadModelConfig

### DIFF
--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/ros_vad_logger.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/ros_vad_logger.hpp
@@ -26,7 +26,7 @@ namespace autoware::tensorrt_vad
  * 
  * 使用例:
  * auto ros_logger = std::make_shared<RosVadLogger>(node);
- * VadConfig config;
+ * VadModelConfig config;
  * // configを設定...
  * VadModel model(config, ros_logger);
  */

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -116,7 +116,7 @@ struct NetConfig
 };
 
 // config for VadModel class
-struct VadConfig
+struct VadModelConfig
 {
   std::string plugins_path;
   int32_t warm_up_num;
@@ -146,7 +146,7 @@ template<typename LoggerType>
 class VadModel
 {
 public:
-  VadModel(const VadConfig& config, std::shared_ptr<LoggerType> logger)
+  VadModel(const VadModelConfig& config, std::shared_ptr<LoggerType> logger)
     : stream_(nullptr), initialized_(false), is_first_frame_(true), config_(config), logger_(std::move(logger))
   {
     // loggerはVadLoggerを継承したclassのみ受け取る
@@ -227,7 +227,7 @@ public:
   bool is_first_frame_;
 
   // 設定情報の保存
-  VadConfig config_;
+  VadModelConfig config_;
 
   // ロガーインスタンス
   std::shared_ptr<VadLogger> logger_;

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_node.hpp
@@ -60,7 +60,7 @@ public:
 
 private:
   // Config loading function
-  void load_vad_config();
+  void load_vad_model_config();
   void load_net_configs();
   void initialize_vad_model();
   void create_camera_image_subscribers(const rclcpp::QoS& sensor_qos);
@@ -96,7 +96,7 @@ private:
 
   // VAD model
   std::unique_ptr<VadModel<RosVadLogger>> vad_model_ptr_{};
-  VadConfig vad_config_;
+  VadModelConfig vad_model_config_;
 
   // VAD interface
   std::unique_ptr<VadInterface> vad_interface_ptr_{};

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/src/vad_node.cpp
@@ -130,8 +130,8 @@ VadNode::VadNode(const rclcpp::NodeOptions & options)
       "/tf_static", tf_static_qos,
       std::bind(&VadNode::tf_static_callback, this, std::placeholders::_1));
 
-  // Load VadConfig
-  load_vad_config();
+  // Load VadModelConfig
+  load_vad_model_config();
 
   // Initialize synchronization strategy
   double sync_tolerance_ms = declare_parameter<double>("sync_params.sync_tolerance_ms");
@@ -243,17 +243,17 @@ void VadNode::initialize_vad_model()
 
   // Create RosVadLogger using the logger
   auto ros_logger = std::make_shared<RosVadLogger>(this->get_logger());
-  vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_config_, ros_logger);
+  vad_model_ptr_ = std::make_unique<VadModel<RosVadLogger>>(vad_model_config_, ros_logger);
 
   RCLCPP_INFO(this->get_logger(), "VAD model and interface initialized successfully");
 }
 
-void VadNode::load_vad_config()
+void VadNode::load_vad_model_config()
 {
   // Load VAD config parameters
-  vad_config_.plugins_path =
+  vad_model_config_.plugins_path =
       this->declare_parameter<std::string>("model_params.plugins_path", "");
-  vad_config_.warm_up_num =
+  vad_model_config_.warm_up_num =
       this->declare_parameter<int>("model_params.warm_up_num", 20);
 
   // Load network configurations
@@ -311,9 +311,9 @@ void VadNode::load_net_configs()
   head_no_prev_config.inputs[input_feature_no_prev]["net"] = net_param_no_prev;
   head_no_prev_config.inputs[input_feature_no_prev]["name"] = name_param_no_prev;
 
-  vad_config_.nets_config.push_back(backbone_config);
-  vad_config_.nets_config.push_back(head_config);
-  vad_config_.nets_config.push_back(head_no_prev_config);
+  vad_model_config_.nets_config.push_back(backbone_config);
+  vad_model_config_.nets_config.push_back(head_config);
+  vad_model_config_.nets_config.push_back(head_no_prev_config);
 }
 
 void VadNode::publish_trajectories(const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_integration.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_integration.cpp
@@ -35,20 +35,20 @@ struct TestConfig {
 };
 
 /**
- * @brief load VadConfig and TestConfig from a YAML file
+ * @brief load VadModelConfig and TestConfig from a YAML file
  * 
  * @param config_path path to the YAML file
- * @return pair of VadConfig and TestConfig
+ * @return pair of VadModelConfig and TestConfig
  * @throws std::runtime_error if YAML loading fails
  */
-std::pair<VadConfig, TestConfig> load_config_from_yaml(const std::string& config_path) {
+std::pair<VadModelConfig, TestConfig> load_config_from_yaml(const std::string& config_path) {
     try {
         YAML::Node yaml_config = YAML::LoadFile(config_path);
         const auto& test_config_node = yaml_config["test_config"];
         
-        VadConfig vad_config;
-        vad_config.plugins_path = test_config_node["plugins_path"].as<std::string>();
-        vad_config.warm_up_num = test_config_node["warm_up_num"].as<int>();
+        VadModelConfig vad_model_config;
+        vad_model_config.plugins_path = test_config_node["plugins_path"].as<std::string>();
+        vad_model_config.warm_up_num = test_config_node["warm_up_num"].as<int>();
         
         const auto& nets = test_config_node["nets"];
         for (const auto& net : nets) {
@@ -67,7 +67,7 @@ std::pair<VadConfig, TestConfig> load_config_from_yaml(const std::string& config
                     net_config.inputs[input.first.as<std::string>()] = input_map;
                 }
             }
-            vad_config.nets_config.push_back(net_config);
+            vad_model_config.nets_config.push_back(net_config);
         }
 
         TestConfig test_config;
@@ -84,7 +84,7 @@ std::pair<VadConfig, TestConfig> load_config_from_yaml(const std::string& config
         const auto& expected_output = test_data["expected_output"];
         test_config.expected_output.trajectory = expected_output["trajectory"].as<std::vector<float>>();
 
-        return {vad_config, test_config};
+        return {vad_model_config, test_config};
     } catch (const YAML::Exception& e) {
         throw std::runtime_error("Failed to load config from YAML: " + std::string(e.what()));
     }
@@ -97,13 +97,13 @@ class VadIntegrationTest : public ::testing::Test {
 protected:
     void SetUp() override {
         mock_logger_ = std::make_shared<MockVadLogger>();
-        auto [vad_config, test_config] = test::load_config_from_yaml(autoware::tensorrt_vad::test::getTestConfigPath());
-        config_ = vad_config;
+        auto [vad_model_config, test_config] = test::load_config_from_yaml(autoware::tensorrt_vad::test::getTestConfigPath());
+        config_ = vad_model_config;
         test_config_ = test_config;
     }
 
     std::shared_ptr<MockVadLogger> mock_logger_;
-    VadConfig config_;
+    VadModelConfig config_;
     test::TestConfig test_config_;
 };
 
@@ -131,8 +131,8 @@ class VadInferIntegrationTest : public ::testing::Test {
 protected:
     void SetUp() override {
         logger_ = std::make_shared<MockVadLogger>();
-        auto [vad_config, test_config] = test::load_config_from_yaml(autoware::tensorrt_vad::test::getTestConfigPath());
-        config_ = vad_config;
+        auto [vad_model_config, test_config] = test::load_config_from_yaml(autoware::tensorrt_vad::test::getTestConfigPath());
+        config_ = vad_model_config;
         test_config_ = test_config;
         
         // 前提条件のチェック
@@ -162,8 +162,8 @@ protected:
         }
     }
 
-    VadConfig createRealConfig() {
-        VadConfig config;
+    VadModelConfig createRealConfig() {
+        VadModelConfig config;
         config.plugins_path = config_.plugins_path;
         config.warm_up_num = config_.warm_up_num;
         
@@ -237,14 +237,14 @@ protected:
     }
 
     std::shared_ptr<MockVadLogger> logger_;
-    VadConfig config_;
+    VadModelConfig config_;
     test::TestConfig test_config_;
     bool integration_test_enabled_ = false;
 };
 
 // 1. モデルが例外を投げずに初期化できることを確認
 TEST_F(VadInferIntegrationTest, ModelInitialization) {
-    VadConfig config = createRealConfig();
+    VadModelConfig config = createRealConfig();
     std::unique_ptr<VadModel<MockVadLogger>> model;
     
     ASSERT_NO_THROW({

--- a/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_model.cpp
+++ b/AV-Solutions/vad-trt/app/autoware_tensorrt_vad/test/test_vad_model.cpp
@@ -36,7 +36,7 @@ protected:
     }
 
     std::shared_ptr<MockVadLogger> mock_logger_;
-    VadConfig config_;
+    VadModelConfig config_;
 };
 
 // 1. VadInputData構造体の基本的な検証
@@ -83,8 +83,8 @@ TEST_F(VadModelTest, VadOutputDataStructure)
     EXPECT_EQ(output_data.predicted_trajectory_.size(), 12);
 }
 
-// 3. VadConfig構造体の検証
-TEST_F(VadModelTest, VadConfigStructure)
+// 3. VadModelConfig構造体の検証
+TEST_F(VadModelTest, VadModelConfigStructure)
 {
     EXPECT_EQ(config_.plugins_path, "/tmp/test_plugin.so");
     EXPECT_EQ(config_.warm_up_num, 1);

--- a/AV-Solutions/vad-trt/app/main.cpp
+++ b/AV-Solutions/vad-trt/app/main.cpp
@@ -194,15 +194,15 @@ public:
               rclcpp::QoS(1), callback));
     }
 
-    // VadConfigを読み込み
-    load_vad_config();
+    // VadModelConfigを読み込み
+    load_vad_model_config();
 
     RCLCPP_INFO(this->get_logger(), "VAD Node has been initialized");
   }
 
-  // VadConfigを取得する関数
-  const autoware::tensorrt_vad::VadConfig &getVadConfig() const {
-    return vad_config_;
+  // VadModelConfigを取得する関数
+  const autoware::tensorrt_vad::VadModelConfig &getVadModelConfig() const {
+    return vad_model_config_;
   }
 
   void publish_trajectory(const std::vector<float> &planning) {
@@ -378,8 +378,8 @@ private:
       rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr>
       camera_subscribers_;
 
-  // VadConfig
-  autoware::tensorrt_vad::VadConfig vad_config_;
+  // VadModelConfig
+  autoware::tensorrt_vad::VadModelConfig vad_model_config_;
 
   // trajectory_timestep parameter
   double trajectory_timestep_;
@@ -397,11 +397,11 @@ private:
     return node_options;
   }
 
-  void load_vad_config() {
+  void load_vad_model_config() {
     // このノード自体からパラメータを読み込み
-    vad_config_.plugins_path =
+    vad_model_config_.plugins_path =
         this->declare_parameter<std::string>("model_params.plugins_path", "");
-    vad_config_.warm_up_num =
+    vad_model_config_.warm_up_num =
         this->declare_parameter<int>("model_params.warm_up_num", 20);
 
     // ネットワーク設定の読み込み
@@ -460,9 +460,9 @@ private:
     head_no_prev_config.inputs[input_feature_no_prev]["name"] =
         name_param_no_prev;
 
-    vad_config_.nets_config.push_back(backbone_config);
-    vad_config_.nets_config.push_back(head_config);
-    vad_config_.nets_config.push_back(head_no_prev_config);
+    vad_model_config_.nets_config.push_back(backbone_config);
+    vad_model_config_.nets_config.push_back(head_config);
+    vad_model_config_.nets_config.push_back(head_no_prev_config);
   }
 
   void onImageReceived(const sensor_msgs::msg::CompressedImage::SharedPtr msg,
@@ -706,13 +706,13 @@ int main(int argc, char **argv) {
   // VADNodeを作成（yamlパスを渡す）
   auto node = std::make_shared<VADNode>(yaml_config_paths);
 
-  // VADNodeからVadConfigを取得
-  const auto &vad_config = node->getVadConfig();
+  // VADNodeからVadModelConfigを取得
+  const auto &vad_model_config = node->getVadModelConfig();
 
   // VadModelを初期化
   auto ros_logger =
       std::make_shared<autoware::tensorrt_vad::RosVadLogger>(node);
-  autoware::tensorrt_vad::VadModel vad_model(vad_config, ros_logger);
+  autoware::tensorrt_vad::VadModel vad_model(vad_model_config, ros_logger);
 
   EventTimer timer;
   std::string data_dir = cfg_dir.string() + "/data/";

--- a/AV-Solutions/vad-trt/app/test/README.md
+++ b/AV-Solutions/vad-trt/app/test/README.md
@@ -65,7 +65,7 @@ make test_help
 - **VadInputDataStructure**: 入力データ構造体のテスト
 - **VadOutputDataStructure**: 出力データ構造体のテスト
 - **LoggerFunctionality**: ロガー機能のテスト
-- **VadConfigStructure**: 設定構造体のテスト
+- **VadModelConfigStructure**: 設定構造体のテスト
 - **NetworkParamClass**: NetworkParamクラスのテスト
 - **TensorRTLoggerClass**: TensorRT用Loggerクラスのテスト
 - **VadModelTypeConstraints**: 型安全性のテスト

--- a/AV-Solutions/vad-trt/app/test/test_vad_model.cpp
+++ b/AV-Solutions/vad-trt/app/test/test_vad_model.cpp
@@ -36,7 +36,7 @@ protected:
     }
 
     std::shared_ptr<MockVadLogger> mock_logger_;
-    VadConfig config_;
+    VadModelConfig config_;
 };
 
 // 1. VadInputData構造体の基本的な検証
@@ -83,8 +83,8 @@ TEST_F(VadModelTest, VadOutputDataStructure)
     EXPECT_EQ(output_data.predicted_trajectory_.size(), 12);
 }
 
-// 3. VadConfig構造体の検証
-TEST_F(VadModelTest, VadConfigStructure)
+// 3. VadModelConfig構造体の検証
+TEST_F(VadModelTest, VadModelConfigStructure)
 {
     EXPECT_EQ(config_.plugins_path, "/tmp/test_plugin.so");
     EXPECT_EQ(config_.warm_up_num, 1);


### PR DESCRIPTION
# Description

- Rename `VadConfig` to `VadModelConfig`

# How this PR is tested

<details>
<summary>log of test for autoware_tensorrt_vad</summary>

```sh
~/ghq/github.com/Shin-kyoto/DL4AGX_ns_rosbag/DL4AGX/AV-Solutions/vad-trt/app/build refactor/rename-vadconfig* ≡ 1m 25s
❯ cd ../demo;../build/vad_app config.json
nvinfer: 8.6.1
[INFO] setting up from config.json
[INFO] assuming data dir is 
[INFO 1753526402.807927563] [vad_node]: VAD Node has been initialized
[INFO 1753526402.812180374] [vad_node]: loading plugin from: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/libplugins.so
[INFO 1753526402.812207354] [vad_node]: -> engine: backbone
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
[INFO 1753526402.886417782] [vad_node]: -> engine: head_no_prev
[INFO 1753526402.886462064] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[INFO 1753526403.109913325] [vad_node]: warm_up=20
[INFO] n_frames=30
[INFO 1753526403.454533538] [rosbag2_storage]: Opened database '/home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/rosbag/output_bag/complete_bag_0.db3' for READ_ONLY.
[INFO 1753526433.043997711] [vad_node]: -> loading head engine: /home/autoware/ghq/github.com/Shin-kyoto/DL4AGX/AV-Solutions/vad-trt/app/demo/engines/vadv1_prev.pts_bbox_head.forward.engine
[INFO 1753526433.044083861] [vad_node]: mlvl_feats.0 <- backbone[out.0]
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
publish trajectory[INFO] 1, cmd=2 finished
publish trajectory[INFO] 2, cmd=2 finished
publish trajectory[INFO] 3, cmd=2 finished
publish trajectory[INFO] 4, cmd=2 finished
publish trajectory[INFO] 5, cmd=2 finished
publish trajectory[INFO] 6, cmd=2 finished
publish trajectory[INFO] 7, cmd=2 finished
publish trajectory[INFO] 8, cmd=2 finished
publish trajectory[INFO] 9, cmd=2 finished
publish trajectory[INFO] 10, cmd=2 finished
publish trajectory[INFO] 11, cmd=2 finished
publish trajectory[INFO] 12, cmd=2 finished
publish trajectorydet: 0.336263, -11.9988, 0.241298, 1.96531, 4.73067, 1.76901, 3.11675, -0.0359743, 7.27872, 0, 0.963657
[INFO] 13, cmd=2 finished
publish trajectory[INFO] 14, cmd=2 finished
publish trajectory[INFO] 15, cmd=2 finished
publish trajectory[INFO] 16, cmd=2 finished
publish trajectory[INFO] 17, cmd=2 finished
publish trajectory[INFO] 18, cmd=2 finished
publish trajectory[INFO] 19, cmd=2 finished
publish trajectory[INFO] 20, cmd=2 finished
publish trajectory[INFO] 21, cmd=2 finished
publish trajectory[INFO] 22, cmd=2 finished
publish trajectory[INFO] 23, cmd=2 finished
publish trajectory[INFO] 24, cmd=2 finished
publish trajectory[INFO] 25, cmd=2 finished
publish trajectory[INFO] 26, cmd=2 finished
publish trajectory[INFO] 27, cmd=2 finished
publish trajectory[INFO] 28, cmd=2 finished
publish trajectory[INFO] 29, cmd=2 finished

❯ ./test_vad_integration
Running main() from gmock_main.cc
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from VadIntegrationTest
[ RUN      ] VadIntegrationTest.ModelInitializationWithRealEngines
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
[       OK ] VadIntegrationTest.ModelInitializationWithRealEngines (570 ms)
[----------] 1 test from VadIntegrationTest (570 ms total)

[----------] 2 tests from VadInferIntegrationTest
[ RUN      ] VadInferIntegrationTest.ModelInitialization

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3740 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3630 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3630 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3630 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3720 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
[       OK ] VadInferIntegrationTest.ModelInitialization (381 ms)
[ RUN      ] VadInferIntegrationTest.RealInferExecution

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3360 "loading plugin from: ../../test/test_data/libplugins.so")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3250 "-> engine: backbone")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
img, [6, 3, 384, 640], type = 0
out.0, [6, 1, 256, 12, 20], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3250 "-> engine: head_no_prev")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3250 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
img_metas.0[shift], [1, 2], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea3340 "warm_up=0")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Data size mismatch: expected 2, got 3

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea31f0 "-> loading head engine: ../../test/test_data/engines/vadv1_prev.pts_bbox_head.forward.engine")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: info(@0x7ffff4ea31f0 "img_feats <- backbone[out.img_feats]")
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
mlvl_feats.0, [1, 6, 256, 12, 20], type = 0
img_metas.0[shift], [1, 2], type = 0
img_metas.0[can_bus], [1, 18], type = 0
img_metas.0[lidar2img], [6, 4, 4], type = 0
prev_bev, [10000, 1, 256], type = 0
out.bev_embed, [10000, 1, 256], type = 0
out.all_cls_scores, [3, 1, 300, 10], type = 0
out.map_all_cls_scores, [3, 1, 100, 3], type = 0
out.map_all_pts_preds, [3, 1, 100, 20, 2], type = 0
out.map_all_bbox_preds, [3, 1, 100, 4], type = 0
out.all_bbox_preds, [3, 1, 300, 10], type = 0
out.all_traj_preds, [3, 1, 300, 6, 12], type = 0
out.all_traj_cls_scores, [3, 1, 300, 6], type = 0
out.ego_fut_preds, [1, 3, 6, 2], type = 0
Data size mismatch: expected 2, got 3
[       OK ] VadInferIntegrationTest.RealInferExecution (798 ms)
[----------] 2 tests from VadInferIntegrationTest (1179 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (1749 ms total)
[  PASSED  ] 3 tests.

~/g/g/S/D/D/A/v/a/a/b/autoware_tensorrt_vad refactor/rename-vadconfig* ≡
❯ ./test_vad_interface 
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VadLidar2ImgTest
[ RUN      ] VadLidar2ImgTest.DummyInputOutput
[       OK ] VadLidar2ImgTest.DummyInputOutput (0 ms)
[----------] 1 test from VadLidar2ImgTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

```

</details>